### PR TITLE
Feature: Parse Docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "front-matter": "^2.0.6",
     "globby": "^4.0.0",
     "handlebars": "^4.0.5",
-    "js-yaml": "^3.5.3"
+    "js-yaml": "^3.5.3",
+    "marked": "^0.3.5"
   },
   "devDependencies": {
     "babel-cli": "^6.5.1",

--- a/src/options.js
+++ b/src/options.js
@@ -1,9 +1,12 @@
 import Handlebars from 'handlebars';
 import yaml from 'js-yaml';
+import marked from 'marked';
 
 const defaults = {
   data: ['src/data/**/*.yaml'],
   dataFn: (contents, path) => yaml.safeLoad(contents),
+  docs: ['src/docs/**/*.md'],
+  docsFn: (contents, path) => marked(contents),
   handlebars: Handlebars,
   helpers   : {},
   keys      : {
@@ -45,6 +48,8 @@ function translateOptions (options = {}) {
   const {
     data,
     dataFn,
+    docs,
+    docsFn,
     handlebars,
     helpers,
     layouts,
@@ -60,6 +65,8 @@ function translateOptions (options = {}) {
   const result = {
     data,
     dataFn,
+    docs,
+    docsFn,
     handlebars,
     helpers,
     layouts,

--- a/src/parse.js
+++ b/src/parse.js
@@ -27,6 +27,19 @@ function parseData ({data, parseFn} = {}) {
 }
 
 /**
+ * Read and parse files in options.docs and parse them
+ * with options.parseFn
+ *
+ * @param {Object} options with
+ *   - {glob} docs        glob of docs files to parse
+ *   - {Function} parseFn parsing function for docs
+ * @return {Promise} resolving to keyed parsed file contents
+ */
+function parseDocs ({docs, parseFn } = {}) {
+  return utils.readFilesKeyed(docs, { contentFn: parseFn });
+}
+
+/**
  * Parse data from pages and build data to be used as part of
  * template compilation context.
  *
@@ -123,6 +136,7 @@ function parsePatterns ({patterns, patternKey} = {}) {
 }
 
 export { parseData,
+         parseDocs,
          parseLayouts,
          parsePages,
          parsePatterns

--- a/test/fixtures/docs/doThis.md
+++ b/test/fixtures/docs/doThis.md
@@ -1,0 +1,3 @@
+* Do This
+* Not This
+* Nor This

--- a/test/options.js
+++ b/test/options.js
@@ -8,6 +8,8 @@ describe ('options', () => {
   var keys = [
     'data',
     'dataFn',
+    'docs',
+    'docsFn',
     'handlebars',
     'helpers',
     'keys',
@@ -38,6 +40,7 @@ describe ('options', () => {
       it ('should translate old properties', () => {
         var translated = translateOptions({
           data: 'foo/bar/baz.yml',
+          docs: 'foo/bar/baz.md',
           materials: 'src/materials/**',
           views: 'myViews',
           layoutIncludes: 'a path',
@@ -48,7 +51,8 @@ describe ('options', () => {
         expect(translated).to.contain.keys(keys);
         expect(translated).not.to.contain.keys('views',
           'materials', 'layoutIncludes');
-        expect(translated).to.contain.keys('pages', 'patterns', 'layouts');
+        expect(translated).to.contain.keys(
+          'docs', 'pages', 'patterns', 'layouts');
         expect(translated.keys).to.contain.keys('patterns');
         expect(translated.keys.patterns).to.equal('materials');
       });

--- a/test/parse.js
+++ b/test/parse.js
@@ -5,6 +5,7 @@ var config = require('./config');
 var expect = chai.expect;
 var parse = require('../dist/parse');
 var yaml  = require('js-yaml');
+var marked = require('marked');
 
 describe ('data', () => {
   describe('parsing layouts', () => {
@@ -41,6 +42,19 @@ describe ('data', () => {
         expect(dataData['data-as-json']).to.be.an('Object')
           .and.to.contain.keys('foo', 'fortunately');
       });
+    });
+  });
+  describe('parsing docs', () => {
+    it ('should build an object with docs files', () => {
+      return parse.parseDocs({
+        docs: config.fixturePath('docs/**/*.md'),
+        parseFn: (contents, path) => marked(contents)
+      })
+        .then(docData => {
+          expect(docData).to.contain.keys('doThis');
+          expect(docData.doThis).to.be.a('string');
+          expect(docData.doThis).to.contain('<ul>');
+        });
     });
   });
   describe('parsing pages', () => {


### PR DESCRIPTION
This single-feature PR (you know, like it should be) adds the ability to parse and build data from docs files. By default it will run `marked` over these but provides a new `option` for using a different parsing function if so desired. 