### PR TITLE
Context Stubbing

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import parseOptions from './options';
-import { prepareData } from './parse';
+import { parseAll } from './parse';
 import { prepareTemplates } from './template';
 
 /**
@@ -9,7 +9,12 @@ import { prepareTemplates } from './template';
  */
 function drizzle (options) {
   const opts = parseOptions(options);
-  return Promise.all([prepareData(opts), prepareTemplates(opts)]);
+  return Promise.all([parseAll(opts), prepareTemplates(opts)]).then(allData => {
+    return {
+      context: allData[0],
+      templates: allData[1]
+    };
+  });
 }
 
 export default drizzle;

--- a/src/options.js
+++ b/src/options.js
@@ -53,9 +53,12 @@ function translateOptions (options = {}) {
     handlebars,
     helpers,
     layouts,
-    materials: patterns,
-    views: pages,
-    layoutIncludes: partials
+    materials: newPatterns,
+    pages,
+    partials,
+    patterns,
+    views: newPages,
+    layoutIncludes: newPartials
   } = options;
 
   const {
@@ -70,9 +73,9 @@ function translateOptions (options = {}) {
     handlebars,
     helpers,
     layouts,
-    pages,
-    patterns,
-    partials
+    pages: pages || newPages,
+    patterns: patterns || newPatterns,
+    partials: partials || newPartials
   };
 
   result.keys = {

--- a/src/parse.js
+++ b/src/parse.js
@@ -36,7 +36,16 @@ function parseData ({data, parseFn} = {}) {
  * @return {Promise} resolving to keyed parsed file contents
  */
 function parseDocs ({docs, parseFn } = {}) {
-  return utils.readFilesKeyed(docs, { contentFn: parseFn });
+  // Wrap the provided parsing function so that we can construct
+  // object entries in a particular way
+  const wrappedParseFn = function (contents, path) {
+    const fileContents = parseFn(contents, path);
+    return {
+      name: utils.titleCase(utils.keyname(path)),
+      contents: fileContents
+    };
+  };
+  return utils.readFilesKeyed(docs, { contentFn: wrappedParseFn });
 }
 
 /**

--- a/src/parse.js
+++ b/src/parse.js
@@ -1,5 +1,6 @@
 import frontMatter from 'front-matter';
 import * as utils from './utils';
+import Promise from 'bluebird';
 
 /**
  * Read files in options.layouts and key them
@@ -144,7 +145,35 @@ function parsePatterns ({patterns, patternKey} = {}) {
   });
 }
 
-export { parseData,
+function parseAll (options = {}) {
+  return Promise.all([
+    parseData({
+      data: options.data,
+      parseFn: options.dataFn
+    }),
+    parseDocs({
+      docs: options.docs,
+      parseFn: options.docsFn
+    }),
+    parseLayouts(options),
+    parsePages({ pages: options.pages }),
+    parsePatterns({
+      patterns: options.patterns,
+      patternKey: options.keys.patterns
+    })
+  ]).then(allData => {
+    return {
+      data    : allData[0],
+      docs    : allData[1],
+      layouts : allData[2],
+      pages   : allData[3],
+      patterns: allData[4]
+    };
+  });
+}
+
+export { parseAll,
+         parseData,
          parseDocs,
          parseLayouts,
          parsePages,

--- a/test/config.js
+++ b/test/config.js
@@ -1,10 +1,20 @@
 var path = require('path');
 
+function fixturePath (glob) {
+  return path.normalize(path.join(fixtures, glob));
+}
 const fixtures = path.join(__dirname, 'fixtures/');
+
 var config = {
+  fixturePath: fixturePath,
   fixtures: fixtures,
-  fixturePath: function (glob) {
-    return path.normalize(path.join(fixtures, glob));
+  fixtureOpts: {
+    data: fixturePath('data/**/*.yaml'),
+    docs: fixturePath('docs/**/*.md'),
+    layouts: fixturePath('layouts/**/*.html'),
+    pages: fixturePath('pages/**/*'),
+    partials: fixturePath('partials/**/*.hbs'),
+    patterns: fixturePath('patterns/**/*.html')
   }
 };
 

--- a/test/index.js
+++ b/test/index.js
@@ -1,20 +1,16 @@
 /* global describe, it */
 var chai = require('chai');
+var config = require('./config');
 var expect = chai.expect;
 var builder = require('../dist/');
-var path = require('path');
-
 
 describe ('drizzle builder integration', () => {
-  const options = {
-    data: path.join(__dirname, 'fixtures/data/*.yaml'),
-    helpers: path.join(__dirname, 'fixtures/helpers/**/*.js'),
-    partials: path.join(__dirname, 'fixtures/partials/*.hbs')
-  };
-  it ('should return data and context',  done => {
-    done();
-    //builder(options).then(drizzleData => {
-    //  done();
-    //});
+  const options = config.fixtureOpts;
+  it ('should return data and context',  () => {
+    return builder(options).then(allData => {
+      expect(allData.context).to.be.an('object');
+      expect(allData.templates).to.be.an('object');
+      // TODO deeper tests as we go
+    });
   });
 });

--- a/test/options.js
+++ b/test/options.js
@@ -37,7 +37,7 @@ describe ('options', () => {
         expect(opts.keys).to.contain.keys('patterns');
       });
     });
-    describe.only('respecting passed options', () => {
+    describe('respecting passed options', () => {
       it('should respect passed paths/globs', () => {
         var options = {
           data: config.fixturePath('data/**/*.yaml'),

--- a/test/options.js
+++ b/test/options.js
@@ -1,5 +1,6 @@
 /* global describe, it */
 var chai = require('chai');
+var config = require('./config');
 var expect = chai.expect;
 var parseOptions = require('../dist/options');
 var translateOptions = parseOptions.translator;
@@ -34,6 +35,23 @@ describe ('options', () => {
         var opts = parseOptions();
         expect(opts.keys).to.be.an('object');
         expect(opts.keys).to.contain.keys('patterns');
+      });
+    });
+    describe.only('respecting passed options', () => {
+      it('should respect passed paths/globs', () => {
+        var options = {
+          data: config.fixturePath('data/**/*.yaml'),
+          docs: config.fixturePath('docs/**/*.md'),
+          layouts: config.fixturePath('layouts/**/*.hbs'),
+          pages: config.fixturePath('pages/**/*'),
+          partials: config.fixturePath('partials/**/*.hbs'),
+          patterns: config.fixturePath('patterns/**/*.hbs')
+        };
+        var opts = parseOptions(options);
+        Object.keys(options).forEach(key => {
+          expect(opts[key]).to.exist.and.to.equal(options[key]);
+        });
+
       });
     });
     describe ('translateOptions', () => {

--- a/test/options.js
+++ b/test/options.js
@@ -39,14 +39,7 @@ describe ('options', () => {
     });
     describe('respecting passed options', () => {
       it('should respect passed paths/globs', () => {
-        var options = {
-          data: config.fixturePath('data/**/*.yaml'),
-          docs: config.fixturePath('docs/**/*.md'),
-          layouts: config.fixturePath('layouts/**/*.hbs'),
-          pages: config.fixturePath('pages/**/*'),
-          partials: config.fixturePath('partials/**/*.hbs'),
-          patterns: config.fixturePath('patterns/**/*.hbs')
-        };
+        var options = config.fixtureOpts;
         var opts = parseOptions(options);
         Object.keys(options).forEach(key => {
           expect(opts[key]).to.exist.and.to.equal(options[key]);

--- a/test/parse-all.js
+++ b/test/parse-all.js
@@ -16,7 +16,7 @@ describe ('all data parsing', () => {
         layouts: config.fixturePath('layouts/**/*.hbs'),
         pages: config.fixturePath('pages/**/*'),
         partials: config.fixturePath('partials/**/*.hbs'),
-        patterns: config.fixturePath('patterns/**/*.hbs')
+        patterns: config.fixturePath('patterns/**/*.html')
       });
       return parse.parseAll(opts).then(dataObj => {
         expect(dataObj).to.be.an('object').and.to.contain.keys(

--- a/test/parse-all.js
+++ b/test/parse-all.js
@@ -1,0 +1,27 @@
+/* global describe, it */
+/* Integration testing for parse module */
+var chai = require('chai');
+var config = require('./config');
+
+var expect = chai.expect;
+var parse = require('../dist/parse');
+var options = require('../dist/options');
+
+describe.only ('all data parsing', () => {
+  describe('building data context object', () => {
+    it('builds a basic context object', () => {
+      var opts = options({
+        data: config.fixturePath('data/**/*.yaml'),
+        docs: config.fixturePath('docs/**/*.md'),
+        layouts: config.fixturePath('layouts/**/*.hbs'),
+        pages: config.fixturePath('pages/**/*'),
+        partials: config.fixturePath('partials/**/*.hbs'),
+        patterns: config.fixturePath('patterns/**/*.hbs')
+      });
+      return parse.parseAll(opts).then(dataObj => {
+        expect(dataObj).to.be.an('object').and.to.contain.keys(
+          'data', 'docs', 'layouts', 'patterns', 'pages');
+      });
+    });
+  });
+});

--- a/test/parse-all.js
+++ b/test/parse-all.js
@@ -7,7 +7,7 @@ var expect = chai.expect;
 var parse = require('../dist/parse');
 var options = require('../dist/options');
 
-describe.only ('all data parsing', () => {
+describe ('all data parsing', () => {
   describe('building data context object', () => {
     it('builds a basic context object', () => {
       var opts = options({

--- a/test/parse.js
+++ b/test/parse.js
@@ -52,8 +52,11 @@ describe ('data', () => {
       })
         .then(docData => {
           expect(docData).to.contain.keys('doThis');
-          expect(docData.doThis).to.be.a('string');
-          expect(docData.doThis).to.contain('<ul>');
+          expect(docData.doThis).to.be.an('object');
+          expect(docData.doThis).to.contain.keys('name', 'contents');
+          expect(docData.doThis.name).to.equal('Dothis');
+          expect(docData.doThis.contents).to.be.a('string');
+          expect(docData.doThis.contents).to.contain('<ul>');
         });
     });
   });


### PR DESCRIPTION
This is a rather dull but functional PR, integrating several chunks of parsing into a exported function for consumption by the main (index) module.

The structure of this context object is going to change—notably, we're changing how we handle `docs` and `pages`—but the generalized functionality (generate a context object and prepare some templates stuff) is the approach to preparing to do the actual build.

As we iron this stuff out, I expect to see the `parseAll` function get cleaner and friendlier. It's helping to show me where there are places that could be refactored better.

/cc @erikjung 