### PR TITLE
Redo Options, Seriously :)

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "repository": "cloudfour/drizzle-builder",
   "dependencies": {
     "bluebird": "^3.3.1",
+    "deepmerge": "^0.2.10",
     "front-matter": "^2.0.6",
     "globby": "^4.0.0",
     "handlebars": "^4.0.5",

--- a/src/options.js
+++ b/src/options.js
@@ -1,3 +1,4 @@
+import merge from 'deepmerge';
 import Handlebars from 'handlebars';
 import yaml from 'js-yaml';
 import marked from 'marked';
@@ -19,80 +20,10 @@ const defaults = {
 };
 
 /**
- * Merge defaults into options.
- * @return {object} merged options
+ * Merge defaults into passed options
  */
-function mergeDefaults (defaultOpts, options = {}) {
-  // Please don't hate me
-  Object.keys(options).map(key => {
-    if (typeof options[key] === 'undefined') { delete options[key]; }
-    if (typeof options[key] === 'object') {
-      options[key] = mergeDefaults(defaultOpts[key], options[key]);
-    }
-  });
-  return Object.assign({}, defaultOpts, options);
+function parseOptions (options = {}) {
+  return merge(defaults, options);
 }
-
-/**
- * Map old options object shape onto new shape
- * so that we can provide backwards-compatibility with fabricator
- * The returned options {object} is of the correct shape to have
- * defaults merged into it.
- *
- * @TODO Eventually, support for fabricator/deprecated things should be
- *       moved into their own module
- * @return {object} User options
- */
-function translateOptions (options = {}) {
-
-  const {
-    data,
-    dataFn,
-    docs,
-    docsFn,
-    handlebars,
-    helpers,
-    layouts,
-    materials: newPatterns,
-    pages,
-    partials,
-    patterns,
-    views: newPages,
-    layoutIncludes: newPartials
-  } = options;
-
-  const {
-    materials: patternKey
-  } = options.keys || {};
-
-  const result = {
-    data,
-    dataFn,
-    docs,
-    docsFn,
-    handlebars,
-    helpers,
-    layouts,
-    pages: pages || newPages,
-    patterns: patterns || newPatterns,
-    partials: partials || newPartials
-  };
-
-  result.keys = {
-    patterns: patternKey
-  };
-  return result;
-}
-
-const parseOptions = options => mergeDefaults(defaults,
-  translateOptions(options));
-
-/**
- * Sigh...
- * > Single exports and multiple exports are mutually exclusive. You have to use
- * > either one the two styles. Some modules combine both styles as follows:
- * http://www.2ality.com/2015/12/babel-commonjs.html
- */
-parseOptions.translator = translateOptions;
 
 export default parseOptions;

--- a/test/options.js
+++ b/test/options.js
@@ -3,14 +3,10 @@ var chai = require('chai');
 var config = require('./config');
 var expect = chai.expect;
 var parseOptions = require('../dist/options');
-var translateOptions = parseOptions.translator;
 
 describe ('options', () => {
   var keys = [
     'data',
-    'dataFn',
-    'docs',
-    'docsFn',
     'handlebars',
     'helpers',
     'keys',
@@ -19,73 +15,12 @@ describe ('options', () => {
     'partials',
     'patterns'
   ];
-  describe ('options parsing', () => {
-    describe('generating options', () => {
-      it ('should not require options to be passed', () => {
+  describe ('parseOptions', () => {
+    describe('generating default options', () => {
+      it ('should generate default options when none passed', () => {
         var opts = parseOptions();
         expect(opts).to.be.an('object');
       });
-      it ('should provide default templating options', () => {
-        var opts = parseOptions();
-        expect(opts).to.contain.keys(keys);
-        expect(opts.handlebars).to.be.an('object');
-        expect(opts.dataFn).to.be.a('function');
-      });
-      it ('should derive naming keys', () => {
-        var opts = parseOptions();
-        expect(opts.keys).to.be.an('object');
-        expect(opts.keys).to.contain.keys('patterns');
-      });
     });
-    describe('respecting passed options', () => {
-      it('should respect passed paths/globs', () => {
-        var options = config.fixtureOpts;
-        var opts = parseOptions(options);
-        Object.keys(options).forEach(key => {
-          expect(opts[key]).to.exist.and.to.equal(options[key]);
-        });
-
-      });
-    });
-    describe ('translateOptions', () => {
-      it ('should translate old properties', () => {
-        var translated = translateOptions({
-          data: 'foo/bar/baz.yml',
-          docs: 'foo/bar/baz.md',
-          materials: 'src/materials/**',
-          views: 'myViews',
-          layoutIncludes: 'a path',
-          keys: {
-            materials: 'materials'
-          }
-        });
-        expect(translated).to.contain.keys(keys);
-        expect(translated).not.to.contain.keys('views',
-          'materials', 'layoutIncludes');
-        expect(translated).to.contain.keys(
-          'docs', 'pages', 'patterns', 'layouts');
-        expect(translated.keys).to.contain.keys('patterns');
-        expect(translated.keys.patterns).to.equal('materials');
-      });
-
-      it ('should translate and parse options correctly', () => {
-        var opts = parseOptions({
-          data: 'foo/bar/baz.yml',
-          materials: 'src/materials/**',
-          views: 'myViews',
-          layoutIncludes: 'a path',
-        });
-        expect(opts).to.be.an('object');
-        expect(opts.data).to.be.a('string');
-        expect(opts.data).to.equal('foo/bar/baz.yml');
-        expect(opts.views).not.to.be;
-        expect(opts.layoutIncludes).not.to.be;
-        expect(opts.pages).to.be.a('string');
-        expect(opts.partials).to.be.a('string');
-        expect(opts.helpers).to.be.an('object').and.to.be.empty;
-        expect(opts).to.contain.keys('layouts', 'partials', 'patterns');
-      });
-    });
-
   });
 });


### PR DESCRIPTION
All right, I've had it. The expense of backwards-compatibility on the options parsing isn't worth it.

This PR greatly simplifies options merging, and uses the `deepmerge` package to do it (one of the few utility dependencies in the project). I'll take the task of porting any existing fabricator setups to use the new options.

The options object in this PR isn't at its end state; it's flat and ugly. I want to merge this and then rebase my working branch onto it and make it beautiful.

Note that there are extremely minimal tests on this options module at present; I'll add on my feature branch.