### PR TITLE
Add Parsers

### DIFF
--- a/src/options.js
+++ b/src/options.js
@@ -27,14 +27,14 @@ var parsers = {
   },
   yaml: {
     pattern: /\.(yaml|yml)$/,
-    parseFn: (contents, path) => yaml.safeLoad(contents)
+    parseFn: (contents, path) => ({ contents: yaml.safeLoad(contents) })
   },
   json: {
     pattern: /\.json$/,
-    parseFn: (contents, path) => JSON.parse(contents)
+    parseFn: (contents, path) => ({ contents: JSON.parse(contents) })
   },
   default: {
-    parseFn: (contents, path) => contents
+    parseFn: (contents, path) => ({ contents: contents })
   }
 };
 

--- a/src/options.js
+++ b/src/options.js
@@ -6,7 +6,7 @@ import frontMatter from 'front-matter';
 
 var parsers = {
   content: {
-    pattern: /\.(html|hbs|handlebars)$/,
+    pattern: '\.(html|hbs|handlebars)$',
     parseFn: (contents, path) => {
       var matter = frontMatter(contents);
       return {

--- a/src/options.js
+++ b/src/options.js
@@ -2,11 +2,28 @@ import merge from 'deepmerge';
 import Handlebars from 'handlebars';
 import yaml from 'js-yaml';
 import marked from 'marked';
+import frontMatter from 'front-matter';
 
 var parsers = {
+  content: {
+    pattern: /\.(html|hbs|handlebars)$/,
+    parseFn: (contents, path) => {
+      var matter = frontMatter(contents);
+      return {
+        contents: matter.body,
+        data: matter.attributes
+      };
+    }
+  },
   markdown: {
     pattern: /\.(md|markdown)$/,
-    parseFn: (contents, path) => marked(contents)
+    parseFn: (contents, path) => {
+      var matter = frontMatter(contents);
+      return {
+        contents: marked(matter.body),
+        data: matter.attributes
+      };
+    }
   },
   yaml: {
     pattern: /\.(yaml|yml)$/,
@@ -15,6 +32,9 @@ var parsers = {
   json: {
     pattern: /\.json$/,
     parseFn: (contents, path) => JSON.parse(contents)
+  },
+  default: {
+    parseFn: (contents, path) => contents
   }
 };
 

--- a/src/options.js
+++ b/src/options.js
@@ -3,6 +3,21 @@ import Handlebars from 'handlebars';
 import yaml from 'js-yaml';
 import marked from 'marked';
 
+var parsers = {
+  markdown: {
+    pattern: /\.(md|markdown)$/,
+    parseFn: (contents, path) => marked(contents)
+  },
+  yaml: {
+    pattern: /\.(yaml|yml)$/,
+    parseFn: (contents, path) => yaml.safeLoad(contents)
+  },
+  json: {
+    pattern: /\.json$/,
+    parseFn: (contents, path) => JSON.parse(contents)
+  }
+};
+
 const defaults = {
   data: ['src/data/**/*.yaml'],
   dataFn: (contents, path) => yaml.safeLoad(contents),
@@ -15,6 +30,7 @@ const defaults = {
   },
   layouts   : ['src/layouts/*'],
   pages     : ['src/pages/**/*'],
+  parsers   : parsers,
   partials  : ['src/partials/**/*'],
   patterns  : ['src/patterns/**/*']
 };

--- a/src/options.js
+++ b/src/options.js
@@ -16,7 +16,7 @@ var parsers = {
     }
   },
   markdown: {
-    pattern: /\.(md|markdown)$/,
+    pattern: '\.(md|markdown)$',
     parseFn: (contents, path) => {
       var matter = frontMatter(contents);
       return {
@@ -26,11 +26,11 @@ var parsers = {
     }
   },
   yaml: {
-    pattern: /\.(yaml|yml)$/,
+    pattern: '\.(yaml|yml)$',
     parseFn: (contents, path) => ({ contents: yaml.safeLoad(contents) })
   },
   json: {
-    pattern: /\.json$/,
+    pattern: '\.json$',
     parseFn: (contents, path) => ({ contents: JSON.parse(contents) })
   },
   default: {

--- a/src/parse.js
+++ b/src/parse.js
@@ -1,4 +1,3 @@
-import frontMatter from 'front-matter';
 import * as utils from './utils';
 import Promise from 'bluebird';
 
@@ -50,12 +49,15 @@ function deepRef (pathKeys, obj) {
   }, obj);
 }
 
+/**
+ * TODO Instead of maintaining keys, figure out what the "top"
+ * directory in a glob match is
+ */
 function parseRecursive (glob, relativeKey, options) {
   const objectData = {};
   return utils.readFiles(glob, options).then(fileData => {
     fileData.forEach(objectFile => {
-      const keys = utils.relativePathArray(objectFile.path,
-        relativeKey);
+      const keys = utils.relativePathArray(objectFile.path, relativeKey);
       const entryKey = utils.keyname(objectFile.path, { stripNumbers: false });
       const pathKey = utils.keyname(objectFile.path);
       deepRef(keys, objectData)[entryKey] = Object.assign({
@@ -96,15 +98,15 @@ function parsePatterns (patterns, options) {
 function parseAll (options = {}) {
   return Promise.all([
     parseData(options.data, options),
-    parseDocs(options.docs, options),
+    parseDocs(options.docs, options), // TODO No such thing as docs
     parseLayouts(options.layouts, options),
     parsePages(options.pages, options),
     parsePatterns(options.pages, options)
   ]).then(allData => {
     return {
       data    : allData[0],
-      docs    : allData[1],
-      layouts : allData[2],
+      docs    : allData[1], // TODO no such thing
+      layouts : allData[2], // TODO Does this really belong here?
       pages   : allData[3],
       patterns: allData[4]
     };

--- a/src/parse.js
+++ b/src/parse.js
@@ -95,20 +95,11 @@ function parsePatterns (patterns, options) {
 
 function parseAll (options = {}) {
   return Promise.all([
-    parseData({
-      data: options.data,
-      parseFn: options.dataFn
-    }),
-    parseDocs({
-      docs: options.docs,
-      parseFn: options.docsFn
-    }),
+    parseData(options.data, options),
+    parseDocs(options.docs, options),
     parseLayouts(options.layouts, options),
-    parsePages({ pages: options.pages }),
-    parsePatterns({
-      patterns: options.patterns,
-      patternKey: options.keys.patterns
-    })
+    parsePages(options.pages, options),
+    parsePatterns(options.pages, options)
   ]).then(allData => {
     return {
       data    : allData[0],

--- a/src/parse.js
+++ b/src/parse.js
@@ -36,17 +36,8 @@ function parseData (data, options) {
  *   - {Function} parseFn parsing function for docs
  * @return {Promise} resolving to keyed parsed file contents
  */
-function parseDocs ({docs, parseFn } = {}) {
-  // Wrap the provided parsing function so that we can construct
-  // object entries in a particular way
-  const wrappedParseFn = function (contents, path) {
-    const fileContents = parseFn(contents, path);
-    return {
-      name: utils.titleCase(utils.keyname(path)),
-      contents: fileContents
-    };
-  };
-  return utils.readFilesKeyed(docs, { contentFn: wrappedParseFn });
+function parseDocs (docs, options) {
+  return utils.readFilesKeyed(docs, options);
 }
 
 /**

--- a/src/parse.js
+++ b/src/parse.js
@@ -10,8 +10,8 @@ import Promise from 'bluebird';
  *  - {glob} layouts   glob of layout files to parse
  * @return {Promise} resolving to keyed file contents
  */
-function parseLayouts ({layouts} = {}) {
-  return utils.readFilesKeyed(layouts);
+function parseLayouts (layouts, options) {
+  return utils.readFilesKeyed(layouts, options);
 }
 
 /**
@@ -23,8 +23,8 @@ function parseLayouts ({layouts} = {}) {
  *   - {Function} parseFn parsing function for data
  * @return {Promise} resolving to keyed parsed file contents
  */
-function parseData ({data, parseFn} = {}) {
-  return utils.readFilesKeyed(data, { contentFn: parseFn });
+function parseData (data, options) {
+  return utils.readFilesKeyed(data, options);
 }
 
 /**
@@ -155,7 +155,7 @@ function parseAll (options = {}) {
       docs: options.docs,
       parseFn: options.docsFn
     }),
-    parseLayouts(options),
+    parseLayouts(options.layouts, options),
     parsePages({ pages: options.pages }),
     parsePatterns({
       patterns: options.patterns,

--- a/src/parse.js
+++ b/src/parse.js
@@ -40,30 +40,6 @@ function parseDocs (docs, options) {
   return utils.readFilesKeyed(docs, options);
 }
 
-/**
- * Parse data from pages and build data to be used as part of
- * template compilation context.
- * @TODO documentation
- * @TODO add option for keys.pages
- */
-function parsePages (pages, options) {
-  const pageData = {};
-  return utils.readFiles(pages, options).then(allPageData => {
-    allPageData.forEach(pageFile => {
-      const keys = utils.relativePathArray(pageFile.path, 'pages');
-      const entryKey = utils.keyname(pageFile.path, { stripNumbers: false });
-      const pathKey = utils.keyname(pageFile.path);
-      deepRef(keys, pageData)[entryKey] = {
-        name: utils.titleCase(pathKey),
-        id  : keys.concat(pathKey).join('.'),
-        data: pageFile.data,
-        contents: pageFile.contents
-      };
-    });
-    return pageData;
-  });
-}
-
 function deepRef (pathKeys, obj) {
   return pathKeys.reduce((prev, curr) => {
     prev[curr] = prev[curr] || {
@@ -92,33 +68,29 @@ function parseRecursive (glob, relativeKey, options) {
 }
 
 /**
+ * Parse data from pages and build data to be used as part of
+ * template compilation context.
+ * @TODO documentation
+ * @TODO add option for keys.pages
+ */
+function parsePages (pages, options) {
+  return parseRecursive(pages, 'pages', options);
+}
+
+/**
  * Parse patterns files and build data object.
  * @TODO document
  */
 function parsePatterns (patterns, options) {
-  const patternData = {};
-  return utils.readFiles(patterns, options).then(fileData => {
-    fileData.forEach(patternFile => {
-      const keys = utils.relativePathArray(patternFile.path,
-        options.keys.patterns);
-      const entryKey = utils.keyname(patternFile.path, { stripNumbers: false });
-      const pathKey = utils.keyname(patternFile.path);
-      deepRef(keys, patternData)[entryKey] = {
-        name: utils.titleCase(pathKey),
-        id  : keys.concat(pathKey).join('.'),
-        data: patternFile.data,
-        contents: patternFile.contents
-      };
-    });
-    // @TODO Figure out how to emulate "local namespacing" of HBS vars
-    // so that one can reference data from front matter in patterns
-    // @TODO Run some fields through markdown
-    // @TODO Do we need to trim whitespace from pattern content?
-    // @TODO Do we need to store pattern data on another object as well?
-    // @TODO Do we need any further sorting?
-    // @TODO Need to register Handlebars partial
-    return patternData;
-  });
+  return parseRecursive(patterns, options.keys.patterns, options);
+
+  // @TODO Figure out how to emulate "local namespacing" of HBS vars
+  // so that one can reference data from front matter in patterns
+  // @TODO Run some fields through markdown
+  // @TODO Do we need to trim whitespace from pattern content?
+  // @TODO Do we need to store pattern data on another object as well?
+  // @TODO Do we need any further sorting?
+  // @TODO Need to register Handlebars partial
 }
 
 function parseAll (options = {}) {

--- a/src/parse.js
+++ b/src/parse.js
@@ -101,7 +101,7 @@ function parseAll (options = {}) {
     parseDocs(options.docs, options), // TODO No such thing as docs
     parseLayouts(options.layouts, options),
     parsePages(options.pages, options),
-    parsePatterns(options.pages, options)
+    parsePatterns(options.patterns, options)
   ]).then(allData => {
     return {
       data    : allData[0],

--- a/src/parse.js
+++ b/src/parse.js
@@ -74,6 +74,23 @@ function deepRef (pathKeys, obj) {
   }, obj);
 }
 
+function parseRecursive (glob, relativeKey, options) {
+  const objectData = {};
+  return utils.readFiles(glob, options).then(fileData => {
+    fileData.forEach(objectFile => {
+      const keys = utils.relativePathArray(objectFile.path,
+        relativeKey);
+      const entryKey = utils.keyname(objectFile.path, { stripNumbers: false });
+      const pathKey = utils.keyname(objectFile.path);
+      deepRef(keys, objectData)[entryKey] = Object.assign({
+        name: utils.titleCase(pathKey),
+        id: keys.concat(pathKey).join('.')
+      }, objectFile);
+    });
+    return objectData;
+  });
+}
+
 /**
  * Parse patterns files and build data object.
  * @TODO document
@@ -136,5 +153,6 @@ export { parseAll,
          parseDocs,
          parseLayouts,
          parsePages,
-         parsePatterns
+         parsePatterns,
+         parseRecursive
        };

--- a/src/parse.js
+++ b/src/parse.js
@@ -44,11 +44,11 @@ function parseDocs (docs, options) {
  * Parse data from pages and build data to be used as part of
  * template compilation context.
  * @TODO documentation
+ * @TODO add option for keys.pages
  */
 function parsePages (pages, options) {
-  const pageOpts = Object.assign({}, options, { stripNumbers: false });
   const pageData = {};
-  return utils.readFiles(pages, pageOpts).then(allPageData => {
+  return utils.readFiles(pages, options).then(allPageData => {
     allPageData.forEach(pageFile => {
       const keys = utils.relativePathArray(pageFile.path, 'pages');
       const entryKey = utils.keyname(pageFile.path, { stripNumbers: false });
@@ -56,8 +56,8 @@ function parsePages (pages, options) {
       deepRef(keys, pageData)[entryKey] = {
         name: utils.titleCase(pathKey),
         id  : keys.concat(pathKey).join('.'),
-        data: pageFile.contents.attributes,
-        contents: pageFile.contents.body
+        data: pageFile.data,
+        contents: pageFile.contents
       };
     });
     return pageData;
@@ -76,27 +76,21 @@ function deepRef (pathKeys, obj) {
 
 /**
  * Parse patterns files and build data object.
- *
- * @param {Object} options with:
- *   {glob} patterns   Where to look for patterns files
- *   {patternKey}      String key for patterns directory, naming
- * @TODO I still don't like the coupling between patternKey and directories
- * @return {Object} Fully-built patterns data object
+ * @TODO document
  */
-function parsePatterns ({patterns, patternKey} = {}) {
+function parsePatterns (patterns, options) {
   const patternData = {};
-  return utils.readFiles(patterns, {
-    contentFn: (contents, path) => frontMatter(contents)
-  }).then(fileData => {
+  return utils.readFiles(patterns, options).then(fileData => {
     fileData.forEach(patternFile => {
-      const keys = utils.relativePathArray(patternFile.path, patternKey);
+      const keys = utils.relativePathArray(patternFile.path,
+        options.keys.patterns);
       const entryKey = utils.keyname(patternFile.path, { stripNumbers: false });
       const pathKey = utils.keyname(patternFile.path);
       deepRef(keys, patternData)[entryKey] = {
         name: utils.titleCase(pathKey),
         id  : keys.concat(pathKey).join('.'),
-        data: patternFile.contents.attributes,
-        contents: patternFile.contents.body
+        data: patternFile.data,
+        contents: patternFile.contents
       };
     });
     // @TODO Figure out how to emulate "local namespacing" of HBS vars

--- a/src/parse.js
+++ b/src/parse.js
@@ -39,16 +39,6 @@ function parseDocs (docs, options) {
   return utils.readFilesKeyed(docs, options);
 }
 
-function deepRef (pathKeys, obj) {
-  return pathKeys.reduce((prev, curr) => {
-    prev[curr] = prev[curr] || {
-      name: utils.titleCase(utils.keyname(curr)),
-      items: {}
-    };
-    return prev[curr].items;
-  }, obj);
-}
-
 /**
  * TODO Instead of maintaining keys, figure out what the "top"
  * directory in a glob match is
@@ -60,7 +50,7 @@ function parseRecursive (glob, relativeKey, options) {
       const keys = utils.relativePathArray(objectFile.path, relativeKey);
       const entryKey = utils.keyname(objectFile.path, { stripNumbers: false });
       const pathKey = utils.keyname(objectFile.path);
-      deepRef(keys, objectData)[entryKey] = Object.assign({
+      utils.deepRef(keys, objectData)[entryKey] = Object.assign({
         name: utils.titleCase(pathKey),
         id: keys.concat(pathKey).join('.')
       }, objectFile);

--- a/src/utils.js
+++ b/src/utils.js
@@ -50,20 +50,28 @@ function removeLeadingNumbers (str) {
 
 /**
  * Retrieve the correct parsing function for a file based on its
- * path.
- * TODO More docs
+ * path. Each parser with a `pattern` property will compile that pattern
+ * to a RegExp and test it against the filepath. If no match is found
+ * against any of the parsers by path pattern, a default parser will be
+ * returned: either a parser keyed by `default` in the `parsers` object
+ * or, lacking that, a default function that leaves the contents of the
+ * file untouched.
+ *
+ * @param {String} filepath
+ * @param {Object} parsers
+ * @see options module
+ * @return {Function} applicable parsing function for file contents
  */
 function matchParser (filepath, parsers = {}) {
   for (var parserKey in parsers) {
     if (parsers[parserKey].pattern) {
-      const regex = new RegExp(parsers[parserKey].pattern);
-      if (regex.test(filepath)) {
+      if (new RegExp(parsers[parserKey].pattern).test(filepath)) {
         return parsers[parserKey].parseFn;
       }
     }
   }
   return (parsers.default && parsers.default.parseFn) ||
-    ((contents, filepath) => contents);
+    ((contents, filepath) => ({ contents: contents }));
 }
 
 /**

--- a/src/utils.js
+++ b/src/utils.js
@@ -75,6 +75,26 @@ function matchParser (filepath, parsers = {}) {
 }
 
 /**
+ * Return (creating if necessary) a deep reference to a nested object
+ * based on path elements. This will mutate `obj` by adding needed properties
+ * to it.
+ *
+ * @param {Array} pathKeys    Elements making up the "path" to the reference
+ * @param {Object}            Object to add needed references to
+ *
+ * @example deepRef(['foo', 'bar', 'baz'], { foo: {} }); // => foo.bar.baz
+ */
+function deepRef (pathKeys, obj) {
+  return pathKeys.reduce((prev, curr) => {
+    prev[curr] = prev[curr] || {
+      name: titleCase(keyname(curr)),
+      items: {}
+    };
+    return prev[curr].items;
+  }, obj);
+}
+
+/**
  * Take a given glob and convert it to a glob that will match directories
  * (instead of files). Return Promise that resolves to matching dirs.
  *
@@ -240,7 +260,8 @@ function relativePathArray (filePath, fromPath) {
   return pathChunks.slice(pathChunks.indexOf(fromPath));
 }
 
-export { dirname,
+export { deepRef,
+         dirname,
          getDirs,
          getLocalDirs,
          getFiles,

--- a/src/utils.js
+++ b/src/utils.js
@@ -55,9 +55,11 @@ function removeLeadingNumbers (str) {
  */
 function matchParser (filepath, parsers = {}) {
   for (var parserKey in parsers) {
-    if (parsers[parserKey].pattern &&
-        parsers[parserKey].pattern.test(filepath)) {
-      return parsers[parserKey].parseFn;
+    if (parsers[parserKey].pattern) {
+      const regex = new RegExp(parsers[parserKey].pattern);
+      if (regex.test(filepath)) {
+        return parsers[parserKey].parseFn;
+      }
     }
   }
   return (parsers.default && parsers.default.parseFn) ||

--- a/src/utils.js
+++ b/src/utils.js
@@ -148,7 +148,7 @@ function readFiles (glob, {
         .then(fileData => {
           const parser = matchParser(filepath, parsers);
           fileData = parser(fileData, filepath);
-          if (typeof fileData === 'string' ) {
+          if (typeof fileData === 'string') {
             fileData = { contents: fileData };
           }
           return Object.assign(fileData, { path: filepath });

--- a/src/utils.js
+++ b/src/utils.js
@@ -148,7 +148,7 @@ function readFiles (glob, {
         .then(fileData => {
           const parser = matchParser(filepath, parsers);
           fileData = parser(fileData, filepath);
-          if (typeof fileData === 'string') {
+          if (typeof fileData === 'string' ) {
             fileData = { contents: fileData };
           }
           return Object.assign(fileData, { path: filepath });

--- a/test/config.js
+++ b/test/config.js
@@ -1,4 +1,7 @@
 var path = require('path');
+var yaml = require('js-yaml');
+var frontMatter = require('front-matter');
+var marked = require('marked');
 
 function fixturePath (glob) {
   return path.normalize(path.join(fixtures, glob));
@@ -15,6 +18,39 @@ var config = {
     pages: fixturePath('pages/**/*'),
     partials: fixturePath('partials/**/*.hbs'),
     patterns: fixturePath('patterns/**/*.html')
+  },
+  parsers: {
+    content: {
+      pattern: /\.(html|hbs|handlebars)$/,
+      parseFn: (contents, path) => {
+        var matter = frontMatter(contents);
+        return {
+          contents: matter.body,
+          data: matter.attributes
+        };
+      }
+    },
+    markdown: {
+      pattern: /\.(md|markdown)$/,
+      parseFn: (contents, path) => {
+        var matter = frontMatter(contents);
+        return {
+          contents: marked(matter.body),
+          data: matter.attributes
+        };
+      }
+    },
+    yaml: {
+      pattern: /\.(yaml|yml)$/,
+      parseFn: (contents, path) => ({ contents: yaml.safeLoad(contents) })
+    },
+    json: {
+      pattern: /\.json$/,
+      parseFn: (contents, path) => ({ contents: JSON.parse(contents) })
+    },
+    default: {
+      parseFn: (contents, path) => ({ contents: contents })
+    }
   }
 };
 

--- a/test/config.js
+++ b/test/config.js
@@ -21,7 +21,7 @@ var config = {
   },
   parsers: {
     content: {
-      pattern: /\.(html|hbs|handlebars)$/,
+      pattern: '\.(html|hbs|handlebars)$',
       parseFn: (contents, path) => {
         var matter = frontMatter(contents);
         return {
@@ -31,7 +31,7 @@ var config = {
       }
     },
     markdown: {
-      pattern: /\.(md|markdown)$/,
+      pattern: '\.(md|markdown)$',
       parseFn: (contents, path) => {
         var matter = frontMatter(contents);
         return {
@@ -41,11 +41,11 @@ var config = {
       }
     },
     yaml: {
-      pattern: /\.(yaml|yml)$/,
+      pattern: '\.(yaml|yml)$/',
       parseFn: (contents, path) => ({ contents: yaml.safeLoad(contents) })
     },
     json: {
-      pattern: /\.json$/,
+      pattern: '\.json$/',
       parseFn: (contents, path) => ({ contents: JSON.parse(contents) })
     },
     default: {

--- a/test/config.js
+++ b/test/config.js
@@ -41,11 +41,11 @@ var config = {
       }
     },
     yaml: {
-      pattern: '\.(yaml|yml)$/',
+      pattern: '\.(yaml|yml)$',
       parseFn: (contents, path) => ({ contents: yaml.safeLoad(contents) })
     },
     json: {
-      pattern: '\.json$/',
+      pattern: '\.json$',
       parseFn: (contents, path) => ({ contents: JSON.parse(contents) })
     },
     default: {

--- a/test/fixtures/patterns/01-fingers/pamp.html
+++ b/test/fixtures/patterns/01-fingers/pamp.html
@@ -1,3 +1,15 @@
+---
+notes: |
+  Pamp!
+
+  #### Usage
+  The base class can be used on a `<button>` or an `<a>`. Anchors that don't have a meaningful `href` should most often be a `<button>` instead.
+
+links:
+  Anchors, Buttons and Accessibility: http://formidable.com/blog/2014/05/08/anchors-buttons-and-accessibility/
+  When to Use the Button Element: https://css-tricks.com/use-button-element/
+---
+
 <ul>
   <li>DING!</li>
 </ul>

--- a/test/options.js
+++ b/test/options.js
@@ -16,11 +16,45 @@ describe ('options', () => {
     'partials',
     'patterns'
   ];
-  describe ('parseOptions', () => {
+  var parserKeys = [
+    'content',
+    'markdown',
+    'json',
+    'yaml',
+    'default'
+  ];
+  describe.only ('parseOptions', () => {
     describe('generating default options', () => {
       it ('should generate default options when none passed', () => {
         var opts = parseOptions();
-        expect(opts).to.be.an('object');
+        expect(opts).to.be.an('object').and.to.contain.keys(keys);
+      });
+      it ('should generate default parsers when none passed', () => {
+        var opts = parseOptions();
+        expect(opts.parsers).to.be.an('object').and.to.contain.keys(parserKeys);
+      });
+    });
+    describe('parsing parsers', () => {
+      var differentParsers = {
+        json: {
+          pattern: /\.json$/,
+          parseFn: (contents, path) => ({ contents: 'foo' }),
+          randomProperty: 'yep'
+        }
+      };
+      it('should accept parser overrides', () => {
+        var opts = parseOptions({parsers: differentParsers});
+        expect(opts.parsers).to.be.an('object').and.to.contain.keys('json');
+        expect(opts.parsers.json.randomProperty).to.be.a('string');
+      });
+      it('should accept additional parsers', () => {
+        var opts = parseOptions({ parsers: {
+          foo: {
+            pattern: /foo/
+          }
+        }});
+        expect(opts.parsers).to.contain.keys('foo');
+        expect(opts.parsers.foo).to.contain.keys('pattern');
       });
     });
   });

--- a/test/options.js
+++ b/test/options.js
@@ -23,7 +23,7 @@ describe ('options', () => {
     'yaml',
     'default'
   ];
-  describe.only ('parseOptions', () => {
+  describe ('parseOptions', () => {
     describe('generating default options', () => {
       it ('should generate default options when none passed', () => {
         var opts = parseOptions();

--- a/test/options.js
+++ b/test/options.js
@@ -12,6 +12,7 @@ describe ('options', () => {
     'keys',
     'layouts',
     'pages',
+    'parsers',
     'partials',
     'patterns'
   ];

--- a/test/parse-all.js
+++ b/test/parse-all.js
@@ -7,7 +7,7 @@ var expect = chai.expect;
 var parse = require('../dist/parse');
 var options = require('../dist/options');
 
-describe.only ('all data parsing', () => {
+describe ('all data parsing', () => {
   describe('building data context object', () => {
     it('builds a basic context object', () => {
       var opts = config.fixtureOpts;

--- a/test/parse-all.js
+++ b/test/parse-all.js
@@ -7,17 +7,15 @@ var expect = chai.expect;
 var parse = require('../dist/parse');
 var options = require('../dist/options');
 
-describe.only ('all data parsing', () => {
+describe ('all data parsing', () => {
   describe('building data context object', () => {
     it('builds a basic context object', () => {
       var opts = config.fixtureOpts;
       opts.parsers = config.parsers;
       opts = options(opts);
-      //console.log(JSON.stringify(opts.parsers, null, '  '));
       return parse.parseAll(opts).then(dataObj => {
-        console.log(dataObj);
-        // expect(dataObj).to.be.an('object').and.to.contain.keys(
-        //   'data', 'docs', 'layouts', 'patterns', 'pages');
+        expect(dataObj).to.be.an('object').and.to.contain.keys('data',
+          'docs', 'pages', 'patterns', 'layouts');
       });
     });
   });

--- a/test/parse-all.js
+++ b/test/parse-all.js
@@ -7,13 +7,13 @@ var expect = chai.expect;
 var parse = require('../dist/parse');
 var options = require('../dist/options');
 
-describe ('all data parsing', () => {
+describe.only ('all data parsing', () => {
   describe('building data context object', () => {
     it('builds a basic context object', () => {
       var opts = config.fixtureOpts;
       opts.parsers = config.parsers;
       opts = options(opts);
-      console.log(opts);
+      //console.log(JSON.stringify(opts.parsers, null, '  '));
       return parse.parseAll(opts).then(dataObj => {
         console.log(dataObj);
         // expect(dataObj).to.be.an('object').and.to.contain.keys(

--- a/test/parse-all.js
+++ b/test/parse-all.js
@@ -7,20 +7,17 @@ var expect = chai.expect;
 var parse = require('../dist/parse');
 var options = require('../dist/options');
 
-describe ('all data parsing', () => {
+describe.only ('all data parsing', () => {
   describe('building data context object', () => {
     it('builds a basic context object', () => {
-      var opts = options({
-        data: config.fixturePath('data/**/*.yaml'),
-        docs: config.fixturePath('docs/**/*.md'),
-        layouts: config.fixturePath('layouts/**/*.hbs'),
-        pages: config.fixturePath('pages/**/*'),
-        partials: config.fixturePath('partials/**/*.hbs'),
-        patterns: config.fixturePath('patterns/**/*.html')
-      });
+      var opts = config.fixtureOpts;
+      opts.parsers = config.parsers;
+      opts = options(opts);
+      console.log(opts);
       return parse.parseAll(opts).then(dataObj => {
-        expect(dataObj).to.be.an('object').and.to.contain.keys(
-          'data', 'docs', 'layouts', 'patterns', 'pages');
+        console.log(dataObj);
+        // expect(dataObj).to.be.an('object').and.to.contain.keys(
+        //   'data', 'docs', 'layouts', 'patterns', 'pages');
       });
     });
   });

--- a/test/parse.js
+++ b/test/parse.js
@@ -4,7 +4,7 @@ var config = require('./config');
 var expect = chai.expect;
 var parse = require('../dist/parse');
 
-describe.only ('parse', () => {
+describe ('parse', () => {
   const defaultParsers = config.parsers;
   describe ('parseRecursive', () => {
     it('should build a recursive, deep object', () => {

--- a/test/parse.js
+++ b/test/parse.js
@@ -49,17 +49,15 @@ describe ('data', () => {
       });
     });
   });
-  describe('parsing docs', () => {
+  describe ('parsing docs', () => {
     it ('should build an object with docs files', () => {
-      return parse.parseDocs({
-        docs: config.fixturePath('docs/**/*.md'),
-        parseFn: (contents, path) => marked(contents)
-      })
+      return parse.parseDocs(config.fixturePath('docs/**/*.md'),
+        { parsers: defaultParsers }
+      )
         .then(docData => {
           expect(docData).to.contain.keys('doThis');
           expect(docData.doThis).to.be.an('object');
-          expect(docData.doThis).to.contain.keys('name', 'contents');
-          expect(docData.doThis.name).to.equal('Dothis');
+          expect(docData.doThis).to.contain.keys('path', 'contents');
           expect(docData.doThis.contents).to.be.a('string');
           expect(docData.doThis.contents).to.contain('<ul>');
         });

--- a/test/parse.js
+++ b/test/parse.js
@@ -4,7 +4,7 @@ var config = require('./config');
 var expect = chai.expect;
 var parse = require('../dist/parse');
 
-describe ('data', () => {
+describe.only ('parse', () => {
   const defaultParsers = config.parsers;
   describe('parsing layouts', () => {
     it ('should correctly parse layout files', () => {
@@ -60,7 +60,7 @@ describe ('data', () => {
         });
     });
   });
-  describe.only ('parsing pages', () => {
+  describe ('parsing pages', () => {
     it ('should correctly build data object from pages', () => {
       return parse.parsePages(config.fixturePath('pages/**/*.html'),
         { parsers: defaultParsers }
@@ -76,10 +76,11 @@ describe ('data', () => {
 
   describe ('parsing patterns', () => {
     it ('builds an object organized by directories', () => {
-      return parse.parsePatterns({
-        patterns: config.fixturePath('patterns/**/*.html'),
-        patternKey: 'patterns'
-      })
+      return parse.parsePatterns(config.fixturePath('patterns/**/*.html'),
+        { keys: { patterns: 'patterns'},
+          parsers: defaultParsers
+        }
+      )
         .then(patternData => {
           expect(patternData).to.contain.keys('patterns');
           expect(patternData.patterns.items).to.contain.keys(
@@ -89,10 +90,11 @@ describe ('data', () => {
         });
     });
     it ('structures each level of object correctly', () => {
-      return parse.parsePatterns({
-        patterns: config.fixturePath('patterns/**/*.html'),
-        patternKey: 'patterns'
-      })
+      return parse.parsePatterns(config.fixturePath('patterns/**/*.html'),
+        { keys: { patterns: 'patterns'},
+          parsers: defaultParsers
+        }
+      )
         .then(patternData => {
           var aPatternObj = patternData.patterns.items['01-fingers'];
           expect(aPatternObj).to.contain.keys(
@@ -107,10 +109,11 @@ describe ('data', () => {
         });
     });
     it ('parses and creates correct value types', () => {
-      return parse.parsePatterns({
-        patterns: config.fixturePath('patterns/**/*.html'),
-        patternKey: 'patterns'
-      })
+      return parse.parsePatterns(config.fixturePath('patterns/**/*.html'),
+        { keys: { patterns: 'patterns'},
+          parsers: defaultParsers
+        }
+      )
         .then(patternData => {
           var aPatternObj = patternData.patterns.items['01-fingers'].items.pamp;
           expect(aPatternObj.name).to.be.a('string').and.to.equal('Pamp');

--- a/test/parse.js
+++ b/test/parse.js
@@ -1,11 +1,8 @@
 /* global describe, it */
 var chai = require('chai');
 var config = require('./config');
-
 var expect = chai.expect;
 var parse = require('../dist/parse');
-var yaml  = require('js-yaml');
-var marked = require('marked');
 
 describe ('data', () => {
   const defaultParsers = config.parsers;
@@ -63,29 +60,16 @@ describe ('data', () => {
         });
     });
   });
-  describe('parsing pages', () => {
+  describe.only ('parsing pages', () => {
     it ('should correctly build data object from pages', () => {
-      return parse.parsePages({ pages: config.fixtures + 'pages/**/*.html' })
+      return parse.parsePages(config.fixturePath('pages/**/*.html'),
+        { parsers: defaultParsers }
+      )
         .then(pageData => {
           expect(pageData).to.be.an('object');
-          expect(pageData).to.contain.keys('pages');
-          expect(pageData.pages).to.contain.keys('items', 'name');
-        });
-    });
-    it ('should correctly parse front matter from pages', () => {
-      return parse.parsePages({ pages: config.fixtures + 'pages/**/*.html' })
-        .then(pageData => {
-          expect(pageData.pages.items.components)
-            .to.contain.keys('name', 'data');
-          expect(pageData.pages.items.components.data).to.be.an('Object');
-          expect(pageData.pages.items.components.data)
-            .to.contain.keys('fabricator', 'title');
-        });
-    });
-    it ('should leave numbers intact in keys', () => {
-      return parse.parsePages({ pages: config.fixtures + 'pages/**/*.html' })
-        .then(pageData => {
-          expect(pageData.pages.items).to.contain.keys('04-sandbox');
+          expect(pageData.pages).to.be.an('object');
+          expect(pageData.pages).to.contain.keys('name', 'items');
+          expect(pageData.pages.items).to.contain.keys('04-sandbox', 'index');
         });
     });
   });

--- a/test/parse.js
+++ b/test/parse.js
@@ -6,6 +6,25 @@ var parse = require('../dist/parse');
 
 describe.only ('parse', () => {
   const defaultParsers = config.parsers;
+  describe ('parseRecursive', () => {
+    it('should build a recursive, deep object', () => {
+      parse.parseRecursive(config.fixturePath('patterns/**/*'),
+        'patterns',
+        { parsers: defaultParsers }
+      ).then(deepObject => {
+        expect(deepObject).to.be.an('object');
+        expect(deepObject).to.contain.keys('patterns');
+        expect(deepObject.patterns.items).to.be.an('object');
+        expect(deepObject.patterns.items['01-fingers']).to.be.an('object');
+        var aPattern = deepObject.patterns.items['01-fingers'];
+        var deepPattern = aPattern.items.pamp;
+        expect(aPattern).to.be.an('object');
+        expect(deepPattern).to.be.an('object');
+        expect(deepPattern).to.contain.keys('name', 'id',
+          'contents', 'data', 'path');
+      });
+    });
+  });
   describe('parsing layouts', () => {
     it ('should correctly parse layout files', () => {
       return parse.parseLayouts(config.fixturePath('layouts/**/*.html'),

--- a/test/parse.js
+++ b/test/parse.js
@@ -8,38 +8,43 @@ var yaml  = require('js-yaml');
 var marked = require('marked');
 
 describe ('data', () => {
+  const defaultParsers = config.parsers;
   describe('parsing layouts', () => {
     it ('should correctly parse layout files', () => {
-      return parse.parseLayouts({
-        layouts: config.fixtures + 'layouts/**/*.html'
-      })
+      return parse.parseLayouts(config.fixturePath('layouts/**/*.html'),
+        { parsers: defaultParsers }
+      )
         .then(layoutData => {
           expect(layoutData).to.be.an('Object')
             .and.to.contain.keys('default');
-          expect(layoutData.default).to.be.a('string');
+          expect(layoutData.default).to.be.an('object');
+          expect(layoutData.default.contents).to.be.a('string');
+          expect(layoutData.default).to.contain.keys('path');
         });
     });
   });
   describe('parsing data', () => {
     it ('should correctly parse YAML data from files', () => {
-      return parse.parseData({
-        data: config.fixtures + 'data/**/*.yaml',
-        parseFn: (contents, path) => yaml.safeLoad(contents)
-      }).then(dataData => {
+      return parse.parseData(
+        config.fixturePath('data/**/*.yaml'),
+        { parsers: defaultParsers }
+      ).then(dataData => {
         expect(dataData).to.be.an('Object')
           .and.to.contain.keys('another-data', 'sample-data');
         expect(dataData['another-data']).to.be.an('Object')
-          .and.to.contain.keys('ding', 'forestry');
+          .and.to.contain.keys('contents', 'path');
+        expect(dataData['another-data'].contents).to.be.an('object');
       });
     });
     it ('should correctly parse JSON data from files', () => {
-      return parse.parseData({
-        data: config.fixtures + '/data/**/*.json',
-        parseFn: (contents, path) => JSON.parse(contents)
-      }).then(dataData => {
+      return parse.parseData(config.fixturePath('data/**/*.json'),
+        { parsers: defaultParsers }
+      ).then(dataData => {
         expect(dataData).to.be.an('Object')
           .and.to.contain.keys('data-as-json');
         expect(dataData['data-as-json']).to.be.an('Object')
+          .and.to.contain.keys('path', 'contents');
+        expect(dataData['data-as-json'].contents).to.be.an('Object')
           .and.to.contain.keys('foo', 'fortunately');
       });
     });

--- a/test/utils.js
+++ b/test/utils.js
@@ -5,7 +5,7 @@ var config = require('./config');
 var path = require('path');
 var utils = require('../dist/utils');
 
-describe.only ('utils', () => {
+describe ('utils', () => {
   describe('titleCase', () => {
     it ('should correctly title-case a string', () => {
       // @TODO move these into fixtures?

--- a/test/utils.js
+++ b/test/utils.js
@@ -105,6 +105,23 @@ describe ('utils', () => {
       expect(result).to.contain('01-');
     });
   });
+  describe('matchParser', () => {
+    it ('should return a default parser function', () => {
+      var parser = utils.matchParser('/foo/bar/baz.txt');
+      expect(parser).to.be.a('function');
+    });
+    it ('should accept a default parser function', () => {
+      var defaultParsers = {
+        default: {
+          pattern: /.*/,
+          parseFn: (contents, filepath) => 'foo'
+        }
+      };
+      var parser = utils.matchParser('/foo/bar/baz.txt', defaultParsers);
+      expect(parser).to.be.a('function');
+      expect(parser('ding')).to.equal('foo');
+    });
+  });
   describe('readFiles', () => {
     it ('should read files from a glob', () => {
       var glob = config.fixturePath('helpers/*.js');

--- a/test/utils.js
+++ b/test/utils.js
@@ -123,6 +123,11 @@ describe ('utils', () => {
     });
   });
   describe('readFiles', () => {
+    var parsers = {
+      default: {
+        parseFn: (contents, filepath) => 'foo'
+      }
+    };
     it ('should read files from a glob', () => {
       var glob = config.fixturePath('helpers/*.js');
       return utils.readFiles(glob).then(allFileData => {
@@ -132,7 +137,7 @@ describe ('utils', () => {
     });
     it ('should run passed function over content', () => {
       var glob = config.fixturePath('helpers/*.js');
-      return utils.readFiles(glob, { contentFn: (content, path) => 'foo' })
+      return utils.readFiles(glob, { parsers })
         .then(allFileData => {
           expect(allFileData).to.have.length.of(3);
           expect(allFileData[0].contents).to.equal('foo');
@@ -142,7 +147,7 @@ describe ('utils', () => {
       var glob = config.fixturePath('files/*');
       // Include dotfiles
       return utils.readFiles(glob, {
-        contentFn: (content, path) => 'foo',
+        parsers: parsers,
         globOpts: { dot: true }
       })
         .then(allFileData => {
@@ -151,6 +156,11 @@ describe ('utils', () => {
     });
   });
   describe('readFilesKeyed', () => {
+    var parsers = {
+      default: {
+        parseFn: (contents, filepath) => 'foo'
+      }
+    };
     it ('should be able to key files by keyname', () => {
       var glob = config.fixturePath('helpers/*.js');
       return utils.readFilesKeyed(glob).then(allFileData => {
@@ -177,11 +187,11 @@ describe ('utils', () => {
       var glob = config.fixturePath('data/*.yaml');
       return utils.readFilesKeyed(glob, {
         keyFn: (path, options) => 'foo' + path,
-        contentFn: (content, path) => 'foo'
+        parsers: parsers
       }).then(allFileData => {
         for (var fileKey in allFileData) {
           expect(fileKey).to.contain('foo');
-          expect(allFileData[fileKey]).to.equal('foo');
+          expect(allFileData[fileKey].contents).to.equal('foo');
         }
       });
     });

--- a/test/utils.js
+++ b/test/utils.js
@@ -5,7 +5,7 @@ var config = require('./config');
 var path = require('path');
 var utils = require('../dist/utils');
 
-describe ('utils', () => {
+describe.only ('utils', () => {
   describe('titleCase', () => {
     it ('should correctly title-case a string', () => {
       // @TODO move these into fixtures?


### PR DESCRIPTION
This PR is not in a golden state yet, but I don't wish it to get too huge. It introduces the idea of "parsers", a way to define how different kinds of files get, well, parsed and built into a data object as preparation for output.

There's still cleanup to do—`docs` are sort of meaningless at this point, more tests need to be written—but the core concept is in place: the ability to define custom parsers for different file types should you wish to. This simplifies the whole notion of parsing files out of `pages`, `patterns`, and `data`. Instead of having a bunch of specialized parsing functions, we can generalize the parsing behavior. There are a set of default parsers, but they can all be overridden, or new ones can be added. 

Keep in mind that this is just about parsing. Generating (i.e. compiling) output is a separate step. 

Overall, except for tests, there is a lot of red in this diff, which is the (pleasing) direction that things are going.

/cc @mrgerardorodriguez 