### PR TITLE
Munge Context Object Structure

### DIFF
--- a/src/options.js
+++ b/src/options.js
@@ -43,6 +43,7 @@ const defaults = {
   handlebars: Handlebars,
   helpers   : {},
   keys      : {
+    pages   : 'pages',
     patterns: 'patterns'
   },
   layouts   : 'src/layouts/*',

--- a/src/options.js
+++ b/src/options.js
@@ -39,18 +39,19 @@ var parsers = {
 };
 
 const defaults = {
-  data: 'src/data/**/*.yaml',
-  handlebars: Handlebars,
-  helpers   : {},
-  keys      : {
-    pages   : 'pages',
-    patterns: 'patterns'
+  data          : 'src/data/**/*.yaml',
+  handlebars    : Handlebars,
+  helpers       : {},
+  keys          : {
+    pages       : 'pages',
+    patterns    : 'patterns'
   },
-  layouts   : 'src/layouts/*',
-  pages     : 'src/pages/**/*',
-  parsers   : parsers,
-  partials  : 'src/partials/**/*',
-  patterns  : 'src/patterns/**/*'
+  layouts       : 'src/layouts/*',
+  markdownFields: ['notes'],
+  pages         : 'src/pages/**/*',
+  parsers       : parsers,
+  partials      : 'src/partials/**/*',
+  patterns      : 'src/patterns/**/*'
 };
 
 /**

--- a/src/parse.js
+++ b/src/parse.js
@@ -29,7 +29,7 @@ function parseLocalData (fileObj, options) {
  * Build a single-page object for the page data object
  */
 function pageEntry (pageFile, keys, options) {
-  const idKeys = keys.map(key => utils.keyname(key));
+  const idKeys = keys.map(utils.keyname);
   const pathKey = utils.keyname(pageFile.path);
   const id = idKeys.concat(pathKey).join('.');
   return Object.assign(parseLocalData(pageFile, options), pageFile, {

--- a/src/parse.js
+++ b/src/parse.js
@@ -65,7 +65,7 @@ function parseAll (options = {}) {
   return Promise.all([
     parseFlat(options.data, options),
     parseFlat(options.layouts, options),
-    parseRecursive(options.pages, 'pages', options),
+    parseRecursive(options.pages, options.keys.pages, options),
     parseRecursive(options.patterns, options.keys.patterns, options)
   ]).then(allData => {
     return {

--- a/src/parse.js
+++ b/src/parse.js
@@ -1,7 +1,22 @@
 import * as utils from './utils';
 import Promise from 'bluebird';
 
+/**
+ * Build a single-page object for the page data object
+ */
+function pageEntry (pageFile, keys) {
+  const idKeys = keys.map(key => utils.keyname(key));
+  const pathKey = utils.keyname(pageFile.path);
+  const id = idKeys.concat(pathKey).join('.');
+  return {
+    id,
+    name: utils.titleCase(pathKey)
+  };
+}
 
+/**
+ * Build a single-pattern object for the pattern object
+ */
 function patternEntry (patternFile, keys) {
   const idKeys = keys.map(key => utils.keyname(key));
   const pathKey = utils.keyname(patternFile.path);
@@ -74,7 +89,7 @@ function parseAll (options = {}) {
   return Promise.all([
     parseFlat(options.data, options),
     parseFlat(options.layouts, options),
-    parseRecursive(options.pages, options.keys.pages, patternEntry, options),
+    parseRecursive(options.pages, options.keys.pages, pageEntry, options),
     parseRecursive(options.patterns,
       options.keys.patterns, patternEntry, options)
   ]).then(allData => {

--- a/src/parse.js
+++ b/src/parse.js
@@ -17,6 +17,10 @@ function parseLocalData (fileObj, options) {
         fileObj.data[mdField] = marked(fileObj.data[mdField]);
       }
     });
+    for (var dataKey in fileObj.data) {
+      fileObj[dataKey] = fileObj.data[dataKey];
+    }
+    delete fileObj.data;
   }
   return fileObj;
 }
@@ -112,7 +116,6 @@ function parseFlat (glob, options) {
 
 // @TODO Figure out how to emulate "local namespacing" of HBS vars
 // so that one can reference data from front matter in patterns
-// @TODO Run some fields through markdown
 // @TODO Do we need to trim whitespace from pattern content?
 // @TODO Do we need to store pattern data on another object as well?
 // @TODO Do we need any further sorting?

--- a/src/parse.js
+++ b/src/parse.js
@@ -22,12 +22,14 @@ function parseRecursive (glob, relativeKey, options) {
   const objectData = {};
   return utils.readFiles(glob, options).then(fileData => {
     fileData.forEach(objectFile => {
-      const keys = utils.relativePathArray(objectFile.path, relativeKey);
+      const keys     = utils.relativePathArray(objectFile.path, relativeKey);
+      const idKeys   = keys.map(key => utils.keyname(key));
       const entryKey = utils.keyname(objectFile.path, { stripNumbers: false });
-      const pathKey = utils.keyname(objectFile.path);
-      utils.deepRef(keys, objectData)[entryKey] = Object.assign({
-        name: utils.titleCase(pathKey),
-        id: keys.concat(pathKey).join('.')
+      const pathKey  = utils.keyname(objectFile.path);
+      const id       = idKeys.concat(pathKey).join('.');
+      utils.deepRef(keys, objectData).items[entryKey] = Object.assign({
+        id,
+        name: utils.titleCase(pathKey)
       }, objectFile);
     });
     return objectData[relativeKey];

--- a/src/utils.js
+++ b/src/utils.js
@@ -77,7 +77,8 @@ function matchParser (filepath, parsers = {}) {
 /**
  * Return (creating if necessary) a deep reference to a nested object
  * based on path elements. This will mutate `obj` by adding needed properties
- * to it.
+ * to it. Think of it like mkdir with a multi-directory path that will create
+ * directory entries if they don't exist.
  *
  * @param {Array} pathKeys    Elements making up the "path" to the reference
  * @param {Object}            Object to add needed references to
@@ -90,7 +91,7 @@ function deepRef (pathKeys, obj) {
       name: titleCase(keyname(curr)),
       items: {}
     };
-    return prev[curr].items;
+    return prev[curr];
   }, obj);
 }
 

--- a/test/config.js
+++ b/test/config.js
@@ -19,6 +19,9 @@ var config = {
     partials: fixturePath('partials/**/*.hbs'),
     patterns: fixturePath('patterns/**/*.html')
   },
+  logObj: obj => {
+    console.log(JSON.stringify(obj, null, '  '));
+  },
   parsers: {
     content: {
       pattern: '\.(html|hbs|handlebars)$',

--- a/test/config.js
+++ b/test/config.js
@@ -15,6 +15,7 @@ var config = {
     data: fixturePath('data/**/*.yaml'),
     docs: fixturePath('docs/**/*.md'),
     layouts: fixturePath('layouts/**/*.html'),
+    markdownFields: ['notes'],
     pages: fixturePath('pages/**/*'),
     partials: fixturePath('partials/**/*.hbs'),
     patterns: fixturePath('patterns/**/*.html')

--- a/test/fixtures/pages/components.html
+++ b/test/fixtures/pages/components.html
@@ -1,10 +1,10 @@
 ---
 title: Components
-fabricator: true
 ---
 
 <h1>{{title}}</h1>
 
-{{#each materials.components.items}}
-  {{~> f-item this}}
+{{#each patterns.components.items}}
+  foo
+  <!-- {{~> f-item this}} -->
 {{/each}}

--- a/test/options.js
+++ b/test/options.js
@@ -11,6 +11,7 @@ describe ('options', () => {
     'helpers',
     'keys',
     'layouts',
+    'markdownFields',
     'pages',
     'parsers',
     'partials',
@@ -52,6 +53,14 @@ describe ('options', () => {
       );
       expect(opts.keys.pages).to.equal('pages');
       expect(opts.keys.patterns).to.equal('bar');
+    });
+    describe('parsing markdownFields', () => {
+      const mdOpts = {
+        markdownFields: ['notes', 'foo']
+      };
+      var opts = parseOptions(mdOpts);
+      expect(opts.markdownFields).to.be.an('Array').and.to
+        .contain('notes', 'foo');
     });
     describe('parsing parsers', () => {
       var differentParsers = {

--- a/test/options.js
+++ b/test/options.js
@@ -33,6 +33,25 @@ describe ('options', () => {
         var opts = parseOptions();
         expect(opts.parsers).to.be.an('object').and.to.contain.keys(parserKeys);
       });
+      it ('should assign keys for different resources', () => {
+        var opts = parseOptions();
+        expect(opts.keys).to.be.an('object').and.to.contain
+        .keys('patterns', 'pages');
+      });
+    });
+    describe('parsing keys', () => {
+      const keyOpts = {
+        keys: {
+          patterns: 'bar',
+          another: 'baz'
+        }
+      };
+      var opts = parseOptions(keyOpts);
+      expect(opts.keys).to.be.an('object').and.to.contain.keys(
+        'pages', 'patterns', 'another'
+      );
+      expect(opts.keys.pages).to.equal('pages');
+      expect(opts.keys.patterns).to.equal('bar');
     });
     describe('parsing parsers', () => {
       var differentParsers = {

--- a/test/parse-all.js
+++ b/test/parse-all.js
@@ -14,11 +14,11 @@ describe ('all data parsing', () => {
       opts.parsers = config.parsers;
       opts = options(opts);
       return parse.parseAll(opts).then(dataObj => {
-        expect(dataObj).to.be.an('object').and.to.contain.keys('data',
+        expect(dataObj).to.be.an('object').and.to.contain.keys(
           'pages', 'patterns', 'layouts');
         expect(dataObj.patterns).to.contain.keys('name', 'items');
         expect(dataObj.pages).to.contain.keys('name', 'items');
-        //config.logObj(dataObj.patterns);
+        //config.logObj(dataObj.pages);
       });
     });
   });

--- a/test/parse-all.js
+++ b/test/parse-all.js
@@ -7,7 +7,7 @@ var expect = chai.expect;
 var parse = require('../dist/parse');
 var options = require('../dist/options');
 
-describe('all data parsing', () => {
+describe ('all data parsing', () => {
   describe('building data context object', () => {
     it('builds a basic context object', () => {
       var opts = config.fixtureOpts;

--- a/test/parse-all.js
+++ b/test/parse-all.js
@@ -7,7 +7,7 @@ var expect = chai.expect;
 var parse = require('../dist/parse');
 var options = require('../dist/options');
 
-describe ('all data parsing', () => {
+describe('all data parsing', () => {
   describe('building data context object', () => {
     it('builds a basic context object', () => {
       var opts = config.fixtureOpts;
@@ -18,6 +18,7 @@ describe ('all data parsing', () => {
           'pages', 'patterns', 'layouts');
         expect(dataObj.patterns).to.contain.keys('name', 'items');
         expect(dataObj.pages).to.contain.keys('name', 'items');
+        //config.logObj(dataObj.patterns);
       });
     });
   });

--- a/test/parse.js
+++ b/test/parse.js
@@ -21,7 +21,7 @@ describe ('parse', () => {
         expect(aPattern).to.be.an('object');
         expect(deepPattern).to.be.an('object');
         expect(deepPattern).to.contain.keys('name', 'id',
-          'contents', 'data', 'path');
+          'contents', 'path');
       });
     });
   });
@@ -117,7 +117,7 @@ describe ('parse', () => {
           expect(aPatternObj.items).to.be.an('object');
           expect(aPatternObj.items.pamp).to.be.an('object');
           expect(aPatternObj.items.pamp).to.contain.keys(
-            'name', 'id', 'data', 'contents'
+            'name', 'id', 'contents', 'notes', 'links'
           );
         });
     });
@@ -134,7 +134,7 @@ describe ('parse', () => {
           expect(aPatternObj.name).to.be.a('string').and.to.equal('Pamp');
           expect(aPatternObj.id).to.be.a('string').and.to.equal(
             'patterns.fingers.pamp');
-          expect(aPatternObj.data).to.be.an('object');
+          expect(aPatternObj.data).not.to.be.ok;
           expect(aPatternObj.contents).to.be.a('string');
         });
     });

--- a/test/parse.js
+++ b/test/parse.js
@@ -68,7 +68,8 @@ describe ('parse', () => {
   describe ('parsing pages', () => {
     it ('should correctly build data object from pages', () => {
       return parse.parseRecursive(config.fixturePath('pages/**/*'), 'pages',
-        { parsers: defaultParsers }
+        { parsers: defaultParsers,
+          markdownFields: ['notes'] }
       )
         .then(pageData => {
           expect(pageData).to.be.an('object');
@@ -88,6 +89,7 @@ describe ('parse', () => {
       return parse.parseRecursive(config.fixturePath('patterns/**/*.html'),
         'patterns',
         { keys: { patterns: 'patterns'},
+          markdownFields: ['notes'],
           parsers: defaultParsers
         }
       )
@@ -102,6 +104,7 @@ describe ('parse', () => {
       return parse.parseRecursive(config.fixturePath('patterns/**/*.html'),
         'patterns',
         { keys: { patterns: 'patterns'},
+          markdownFields: ['notes'],
           parsers: defaultParsers
         }
       )
@@ -122,6 +125,7 @@ describe ('parse', () => {
       return parse.parseRecursive(config.fixturePath('patterns/**/*.html'),
         'patterns',
         { keys: { patterns: 'patterns'},
+          markdownFields: ['notes'],
           parsers: defaultParsers
         }
       )

--- a/test/parse.js
+++ b/test/parse.js
@@ -77,7 +77,7 @@ describe ('parse', () => {
             '04-sandbox', 'index', 'doThis');
           expect(pageData.items.doThis).to.be.an('object');
           expect(pageData.items.doThis.contents).to.be.a('string');
-          expect(pageData.items.subfolder.items.subpage)
+          expect(pageData.subfolder.items.subpage)
             .to.be.an('object');
         });
     });
@@ -92,11 +92,10 @@ describe ('parse', () => {
         }
       )
         .then(patternData => {
-          expect(patternData).to.contain.keys('name', 'items');
-          expect(patternData.items).to.contain.keys(
-            '01-fingers', 'components', 'pink');
-          expect(patternData.items.components.items).to.contain.keys(
-            'button', 'orange');
+          expect(patternData).to.contain.keys(
+            'name', 'items', '01-fingers', 'components');
+          expect(patternData.items).to.contain.keys('pink');
+          expect(patternData.components.items).to.contain.keys('orange');
         });
     });
     it ('structures each level of object correctly', () => {
@@ -107,7 +106,7 @@ describe ('parse', () => {
         }
       )
         .then(patternData => {
-          var aPatternObj = patternData.items['01-fingers'];
+          var aPatternObj = patternData['01-fingers'];
           expect(aPatternObj).to.contain.keys(
             'name', 'items'
           );
@@ -127,10 +126,10 @@ describe ('parse', () => {
         }
       )
         .then(patternData => {
-          var aPatternObj = patternData.items['01-fingers'].items.pamp;
+          var aPatternObj = patternData['01-fingers'].items.pamp;
           expect(aPatternObj.name).to.be.a('string').and.to.equal('Pamp');
           expect(aPatternObj.id).to.be.a('string').and.to.equal(
-            'patterns.01-fingers.pamp');
+            'patterns.fingers.pamp');
           expect(aPatternObj.data).to.be.an('object');
           expect(aPatternObj.contents).to.be.a('string');
         });


### PR DESCRIPTION
This admittedly-mundane PR massages the shapes of the context objects being generated for patterns and pages so that I can move into beginning to output things. It's mostly concerned with creating correctly-nested and -keyed objects for later traversal and use. 

It's pretty boring.

But it was kind of hard.

zzzzzz recursion...

/cc @mrgerardorodriguez 