### PR TITLE
Basic Pages Output

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "globby": "^4.0.0",
     "handlebars": "^4.0.5",
     "js-yaml": "^3.5.3",
-    "marked": "^0.3.5"
+    "marked": "^0.3.5",
+    "mkdirp": "^0.5.1"
   },
   "devDependencies": {
     "babel-cli": "^6.5.1",

--- a/src/index.js
+++ b/src/index.js
@@ -3,17 +3,36 @@ import { parseAll } from './parse';
 import { prepareTemplates } from './template';
 
 /**
- * Build the drizzle output
+ * Parse resource files and prepare templates and handlebars.
+ * @TODO Possibly move into a different module.
  *
- * @return {Promise}; resolves to [dataObj, Handlebars] for now
+ * @param {Object} options
+ * @return {Promise}
+ */
+function prepare (options) {
+  return Promise.all([
+    parseAll(options),
+    prepareTemplates(options)
+  ]).then(allData => {
+    return {
+      context: allData[0],
+      handlebars: allData[1]
+    };
+  });
+}
+
+/**
+ * Build the drizzle!
+ *
+ * @return {Promise}; ...
  */
 function drizzle (options) {
   const opts = parseOptions(options);
-  return Promise.all([parseAll(opts), prepareTemplates(opts)]).then(allData => {
+  return prepare(opts).then(drizzleData => {
     return {
-      context: allData[0],
-      options: opts,
-      templates: allData[1]
+      context: drizzleData.context,
+      handlebars: drizzleData.handlebars,
+      options: opts
     };
   });
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,25 +1,5 @@
 import parseOptions from './options';
-import { parseAll } from './parse';
-import { prepareTemplates } from './template';
-
-/**
- * Parse resource files and prepare templates and handlebars.
- * @TODO Possibly move into a different module.
- *
- * @param {Object} options
- * @return {Promise}
- */
-function prepare (options) {
-  return Promise.all([
-    parseAll(options),
-    prepareTemplates(options)
-  ]).then(allData => {
-    return {
-      context: allData[0],
-      handlebars: allData[1]
-    };
-  });
-}
+import prepare from './prepare';
 
 /**
  * Build the drizzle!

--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,7 @@ function drizzle (options) {
   return Promise.all([parseAll(opts), prepareTemplates(opts)]).then(allData => {
     return {
       context: allData[0],
+      options: opts,
       templates: allData[1]
     };
   });

--- a/src/options.js
+++ b/src/options.js
@@ -40,6 +40,7 @@ var parsers = {
 
 const defaults = {
   data          : 'src/data/**/*.yaml',
+  dest          : 'dist',
   handlebars    : Handlebars,
   helpers       : {},
   keys          : {

--- a/src/options.js
+++ b/src/options.js
@@ -38,6 +38,7 @@ var parsers = {
   }
 };
 
+/* TODO: options for path prefixes for patterns, pages */
 const defaults = {
   data          : 'src/data/**/*.yaml',
   dest          : 'dist',

--- a/src/pages.js
+++ b/src/pages.js
@@ -1,6 +1,7 @@
 import { applyTemplate } from './template';
 import path from 'path';
 import Promise from 'bluebird';
+/* TODO: FS stuff in separate module */
 import {writeFile as writeFileCB} from 'fs';
 import {mkdirp as mkdirpCB} from 'mkdirp';
 var writeFile = Promise.promisify(writeFileCB);
@@ -12,6 +13,9 @@ function isPage (obj) {
     obj.resourceType === 'page');
 }
 
+/**
+ * TODO: Move to another module, separate out fs stuff
+ */
 function writePage (page, drizzleData) {
   const templateContext = Object.assign({}, drizzleData.context, page);
   const compiled = applyTemplate(page.contents,
@@ -23,6 +27,9 @@ function writePage (page, drizzleData) {
   return writeFile(outputPath, compiled);
 }
 
+/**
+ * TODO: Comment
+ */
 function writePages (pages, drizzleData, writePromises = []) {
   if (isPage(pages)) {
     return writePage(pages, drizzleData);
@@ -34,6 +41,10 @@ function writePages (pages, drizzleData, writePromises = []) {
   return writePromises;
 }
 
+/**
+ * TODO: Comment
+ * TODO: Better resolve/return value
+ */
 function pages (drizzleData) {
   return Promise.all(writePages(drizzleData.context.pages, drizzleData))
     .then(() => {

--- a/src/pages.js
+++ b/src/pages.js
@@ -1,9 +1,24 @@
 import * as utils from './utils';
 import Promise from 'bluebird';
 
+function isPage (obj) {
+  return (typeof obj === 'object' &&
+    obj.resourceType &&
+    obj.resourceType === 'page');
+}
+
+function writePage (page, drizzleData) {
+  console.log('writing page', page.outputPath);
+}
+
 function writePages (pages, drizzleData) {
-  //console.log(JSON.stringify(pages, null, '  '));
-  return {};
+  if (isPage(pages)) {
+    return writePage(pages, drizzleData);
+  }
+  for (var pageKey in pages) {
+    writePages(pages[pageKey], drizzleData);
+  }
+  return {}; // TODO
 }
 
 function pages (drizzleData) {

--- a/src/pages.js
+++ b/src/pages.js
@@ -1,4 +1,10 @@
 import { applyTemplate } from './template';
+import path from 'path';
+import Promise from 'bluebird';
+import {writeFile as writeFileCB} from 'fs';
+import {mkdirp as mkdirpCB} from 'mkdirp';
+var writeFile = Promise.promisify(writeFileCB);
+var mkdirp    = Promise.promisify(mkdirpCB);
 
 function isPage (obj) {
   return (typeof obj === 'object' &&
@@ -10,7 +16,11 @@ function writePage (page, drizzleData) {
   const templateContext = Object.assign({}, drizzleData.context, page);
   const compiled = applyTemplate(page.contents,
     templateContext, drizzleData.options);
-  return compiled;
+  const outputPath = path.normalize(path.join(
+    drizzleData.options.dest,
+    page.outputPath));
+  mkdirp(path.dirname(outputPath));
+  return writeFile(outputPath, compiled);
 }
 
 function writePages (pages, drizzleData) {
@@ -20,7 +30,7 @@ function writePages (pages, drizzleData) {
   for (var pageKey in pages) {
     writePages(pages[pageKey], drizzleData);
   }
-  return {}; // TODO
+  return {};
 }
 
 function pages (drizzleData) {

--- a/src/pages.js
+++ b/src/pages.js
@@ -1,5 +1,4 @@
-import * as utils from './utils';
-import Promise from 'bluebird';
+import { applyTemplate } from './template';
 
 function isPage (obj) {
   return (typeof obj === 'object' &&
@@ -8,7 +7,10 @@ function isPage (obj) {
 }
 
 function writePage (page, drizzleData) {
-  console.log('writing page', page.outputPath);
+  const templateContext = Object.assign({}, drizzleData.context, page);
+  const compiled = applyTemplate(page.contents,
+    templateContext, drizzleData.options);
+  return compiled;
 }
 
 function writePages (pages, drizzleData) {

--- a/src/pages.js
+++ b/src/pages.js
@@ -1,12 +1,13 @@
 import * as utils from './utils';
 import Promise from 'bluebird';
 
-function outputPages (pages, context, options, handlebars) {
-  // write me
+function writePages (pages, drizzleData) {
+  //console.log(JSON.stringify(pages, null, '  '));
+  return {};
 }
 
-function buildPages (drizzleData) {
-  // outputPages(context.pages, context, options, handlebars);
+function pages (drizzleData) {
+  return writePages(drizzleData.context.pages, drizzleData);
 }
 
-export default buildPages;
+export default pages;

--- a/src/pages.js
+++ b/src/pages.js
@@ -1,14 +1,12 @@
 import * as utils from './utils';
 import Promise from 'bluebird';
 
-function outputPages(pages, context, options, handlebars) {
-  if (pages.items) {
-    outputPages(pages.items, context, options, handlebars);
-  }
+function outputPages (pages, context, options, handlebars) {
+  // write me
 }
 
 function buildPages (options, context, handlebars) {
-  const pages = context.pages;
+  outputPages(context.pages, context, options, handlebars);
 }
 
 export default buildPages;

--- a/src/pages.js
+++ b/src/pages.js
@@ -23,18 +23,22 @@ function writePage (page, drizzleData) {
   return writeFile(outputPath, compiled);
 }
 
-function writePages (pages, drizzleData) {
+function writePages (pages, drizzleData, writePromises = []) {
   if (isPage(pages)) {
     return writePage(pages, drizzleData);
   }
   for (var pageKey in pages) {
-    writePages(pages[pageKey], drizzleData);
+    writePromises = writePromises.concat(
+      writePages(pages[pageKey], drizzleData, writePromises));
   }
-  return {};
+  return writePromises;
 }
 
 function pages (drizzleData) {
-  return writePages(drizzleData.context.pages, drizzleData);
+  return Promise.all(writePages(drizzleData.context.pages, drizzleData))
+    .then(() => {
+      return true;
+    });
 }
 
 export default pages;

--- a/src/pages.js
+++ b/src/pages.js
@@ -5,8 +5,8 @@ function outputPages (pages, context, options, handlebars) {
   // write me
 }
 
-function buildPages (options, context, handlebars) {
-  outputPages(context.pages, context, options, handlebars);
+function buildPages (drizzleData) {
+  // outputPages(context.pages, context, options, handlebars);
 }
 
 export default buildPages;

--- a/src/pages.js
+++ b/src/pages.js
@@ -1,0 +1,14 @@
+import * as utils from './utils';
+import Promise from 'bluebird';
+
+function outputPages(pages, context, options, handlebars) {
+  if (pages.items) {
+    outputPages(pages.items, context, options, handlebars);
+  }
+}
+
+function buildPages (options, context, handlebars) {
+  const pages = context.pages;
+}
+
+export default buildPages;

--- a/src/parse.js
+++ b/src/parse.js
@@ -34,7 +34,8 @@ function pageEntry (pageFile, keys, options) {
   const id = idKeys.concat(pathKey).join('.');
   return Object.assign(parseLocalData(pageFile, options), pageFile, {
     id,
-    name: utils.titleCase(pathKey)
+    name: utils.titleCase(pathKey),
+    resourceType: 'page'
   });
 }
 

--- a/src/parse.js
+++ b/src/parse.js
@@ -83,7 +83,7 @@ function parsePages (options) {
       const keys       = utils.relativePathArray(
         pageFile.path, options.keys.pages);
       keys.shift();
-      const outputPath = keys.join(path.sep);
+      const outputPath = path.join(keys.join(path.sep), entryKey + '.html');
       utils.deepObj(keys, pageData)[entryKey] = Object.assign(
         parseLocalData(pageFile, options), pageFile, {
           outputPath,

--- a/src/parse.js
+++ b/src/parse.js
@@ -1,6 +1,7 @@
 import * as utils from './utils';
 import Promise from 'bluebird';
 import marked from 'marked';
+import path from 'path';
 
 /**
  * Given an object representing a page or pattern or other file:
@@ -26,27 +27,6 @@ function parseLocalData (fileObj, options) {
 }
 
 /**
- * Build a single-page object for the page data object
- */
-function pageEntry (pageFile, keys, options) {
-  const idKeys = keys.map(utils.keyname);
-  const pathKey = utils.keyname(pageFile.path);
-  const id = idKeys.concat(pathKey).join('.');
-  return Object.assign(parseLocalData(pageFile, options), pageFile, {
-    id,
-    name: utils.titleCase(pathKey),
-    resourceType: 'page'
-  });
-}
-
-/**
- * Parse pages files and build context object
- */
-function parsePages (options) {
-  return parseRecursive(options.pages, options.keys.pages, pageEntry, options);
-}
-
-/**
  * Build a single-pattern object for the pattern object
  */
 function patternEntry (patternFile, keys, options) {
@@ -69,17 +49,7 @@ function parsePatterns (options) {
 }
 /**
  * Parse a file structure of files matching `glob` into a nested object
- * structure:
- * { name: 'Directory Name in Title Case',
- *   items: {
- *     name: 'Sub Directory',
- *     items: { ... },
- *     'item-in-topdirectory': {
- *       name: 'Item In Top Directory',
- *       items: {   }
- *     }
- *   }
- * }
+ * structure: @TODO
  *
  * Each object in `items` will be an object structured per the return value
  * of the parser associated with that file path pattern.
@@ -98,6 +68,29 @@ function parseRecursive (glob, relativeKey, entryFn, options) {
         .items[entryKey] = entryFn(objectFile, keys, options);
     });
     return objectData[relativeKey];
+  });
+}
+
+/**
+ * Parse the pages...TODO
+ */
+function parsePages (options) {
+  const pageData = {};
+
+  return utils.readFiles(options.pages, options).then(fileData => {
+    fileData.forEach(pageFile => {
+      const entryKey   = utils.keyname(pageFile.path, { stripNumbers: false });
+      const keys       = utils.relativePathArray(
+        pageFile.path, options.keys.pages);
+      keys.shift();
+      const outputPath = keys.join(path.sep);
+      utils.deepObj(keys, pageData)[entryKey] = Object.assign(
+        parseLocalData(pageFile, options), pageFile, {
+          outputPath,
+          resourceType: 'page'
+        });
+    });
+    return pageData;
   });
 }
 
@@ -143,5 +136,6 @@ function parseAll (options = {}) {
 
 export { parseAll,
          parseFlat,
+         parsePages,
          parseRecursive
        };

--- a/src/prepare.js
+++ b/src/prepare.js
@@ -1,0 +1,23 @@
+import { parseAll } from './parse';
+import { prepareTemplates } from './template';
+
+/**
+ * Parse resource files and prepare templates and handlebars.
+ * @TODO Possibly move into a different module.
+ *
+ * @param {Object} options
+ * @return {Promise}
+ */
+function prepare (options) {
+  return Promise.all([
+    parseAll(options),
+    prepareTemplates(options)
+  ]).then(allData => {
+    return {
+      context: allData[0],
+      handlebars: allData[1]
+    };
+  });
+}
+
+export default prepare;

--- a/src/template.js
+++ b/src/template.js
@@ -78,4 +78,11 @@ function prepareTemplates (opts) {
   });
 }
 
-export { prepareTemplates, prepareHelpers, preparePartials };
+function applyTemplate (template, context, options) {
+  if (typeof template !== 'function') {
+    template = options.handlebars.compile(template);
+  }
+  return template(context);
+}
+
+export { applyTemplate, prepareTemplates, prepareHelpers, preparePartials };

--- a/src/utils.js
+++ b/src/utils.js
@@ -96,6 +96,16 @@ function deepRef (pathKeys, obj) {
 }
 
 /**
+ * TODO: Temporary
+ */
+function deepObj (pathKeys, obj) {
+  return pathKeys.reduce((prev, curr) => {
+    prev[curr] = prev[curr] || {};
+    return prev[curr];
+  }, obj);
+}
+
+/**
  * Take a given glob and convert it to a glob that will match directories
  * (instead of files). Return Promise that resolves to matching dirs.
  *
@@ -262,6 +272,7 @@ function relativePathArray (filePath, fromPath) {
 }
 
 export { deepRef,
+         deepObj,
          dirname,
          getDirs,
          getLocalDirs,

--- a/test/config.js
+++ b/test/config.js
@@ -3,6 +3,9 @@ var yaml = require('js-yaml');
 var frontMatter = require('front-matter');
 var marked = require('marked');
 
+var prepareDrizzle = require('../dist/prepare');
+var parseOptions = require('../dist/options');
+
 const fixtures = path.join(__dirname, 'fixtures/');
 const parsers = {
   content: {
@@ -42,9 +45,15 @@ function fixturePath (glob) {
   return path.normalize(path.join(fixtures, glob));
 }
 
+function prepare (options) {
+  const opts = parseOptions(options);
+  return prepareDrizzle(opts);
+}
 var config = {
-  fixturePath: fixturePath,
-  fixtures: fixtures,
+  parsers,
+  fixturePath,
+  fixtures,
+  prepare,
   fixtureOpts: {
     data: fixturePath('data/**/*'),
     layouts: fixturePath('layouts/**/*.html'),
@@ -56,8 +65,7 @@ var config = {
   },
   logObj: obj => {
     console.log(JSON.stringify(obj, null, '  '));
-  },
-  parsers: parsers
+  }
 };
 
 module.exports = config;

--- a/test/config.js
+++ b/test/config.js
@@ -3,59 +3,61 @@ var yaml = require('js-yaml');
 var frontMatter = require('front-matter');
 var marked = require('marked');
 
+const fixtures = path.join(__dirname, 'fixtures/');
+const parsers = {
+  content: {
+    pattern: '\.(html|hbs|handlebars)$',
+    parseFn: (contents, path) => {
+      var matter = frontMatter(contents);
+      return {
+        contents: matter.body,
+        data: matter.attributes
+      };
+    }
+  },
+  markdown: {
+    pattern: '\.(md|markdown)$',
+    parseFn: (contents, path) => {
+      var matter = frontMatter(contents);
+      return {
+        contents: marked(matter.body),
+        data: matter.attributes
+      };
+    }
+  },
+  yaml: {
+    pattern: '\.(yaml|yml)$',
+    parseFn: (contents, path) => ({ contents: yaml.safeLoad(contents) })
+  },
+  json: {
+    pattern: '\.json$',
+    parseFn: (contents, path) => ({ contents: JSON.parse(contents) })
+  },
+  default: {
+    parseFn: (contents, path) => ({ contents: contents })
+  }
+};
+
 function fixturePath (glob) {
   return path.normalize(path.join(fixtures, glob));
 }
-const fixtures = path.join(__dirname, 'fixtures/');
 
 var config = {
   fixturePath: fixturePath,
   fixtures: fixtures,
   fixtureOpts: {
-    data: fixturePath('data/**/*.yaml'),
-    docs: fixturePath('docs/**/*.md'),
+    data: fixturePath('data/**/*'),
     layouts: fixturePath('layouts/**/*.html'),
     markdownFields: ['notes'],
     pages: fixturePath('pages/**/*'),
+    parsers: parsers,
     partials: fixturePath('partials/**/*.hbs'),
-    patterns: fixturePath('patterns/**/*.html')
+    patterns: fixturePath('patterns/**/*')
   },
   logObj: obj => {
     console.log(JSON.stringify(obj, null, '  '));
   },
-  parsers: {
-    content: {
-      pattern: '\.(html|hbs|handlebars)$',
-      parseFn: (contents, path) => {
-        var matter = frontMatter(contents);
-        return {
-          contents: matter.body,
-          data: matter.attributes
-        };
-      }
-    },
-    markdown: {
-      pattern: '\.(md|markdown)$',
-      parseFn: (contents, path) => {
-        var matter = frontMatter(contents);
-        return {
-          contents: marked(matter.body),
-          data: matter.attributes
-        };
-      }
-    },
-    yaml: {
-      pattern: '\.(yaml|yml)$',
-      parseFn: (contents, path) => ({ contents: yaml.safeLoad(contents) })
-    },
-    json: {
-      pattern: '\.json$',
-      parseFn: (contents, path) => ({ contents: JSON.parse(contents) })
-    },
-    default: {
-      parseFn: (contents, path) => ({ contents: contents })
-    }
-  }
+  parsers: parsers
 };
 
 module.exports = config;

--- a/test/config.js
+++ b/test/config.js
@@ -4,7 +4,7 @@ var frontMatter = require('front-matter');
 var marked = require('marked');
 
 var prepareDrizzle = require('../dist/prepare');
-var parseOptions = require('../dist/options');
+var parseDrizzleOptions = require('../dist/options');
 
 const fixtures = path.join(__dirname, 'fixtures/');
 const parsers = {
@@ -45,15 +45,30 @@ function fixturePath (glob) {
   return path.normalize(path.join(fixtures, glob));
 }
 
-function prepare (options) {
-  const opts = parseOptions(options);
-  return prepareDrizzle(opts);
+function parseOptions (options) {
+  return parseDrizzleOptions(options);
 }
+function prepare (options) {
+  return prepareDrizzle(options);
+}
+function prepareAll (options) {
+  var opts = parseOptions(options);
+  return prepare(opts).then(drizzleData => {
+    return {
+      context: drizzleData.context,
+      handlebars: drizzleData.handlebars,
+      options: opts
+    };
+  });
+}
+
 var config = {
   parsers,
   fixturePath,
   fixtures,
+  parseOptions,
   prepare,
+  prepareAll,
   fixtureOpts: {
     data: fixturePath('data/**/*'),
     layouts: fixturePath('layouts/**/*.html'),

--- a/test/config.js
+++ b/test/config.js
@@ -71,6 +71,7 @@ var config = {
   prepareAll,
   fixtureOpts: {
     data: fixturePath('data/**/*'),
+    dest: './test/dist',
     layouts: fixturePath('layouts/**/*.html'),
     markdownFields: ['notes'],
     pages: fixturePath('pages/**/*'),

--- a/test/fixtures/pages/04-sandbox.html
+++ b/test/fixtures/pages/04-sandbox.html
@@ -9,25 +9,3 @@ fabricator: true
   These are mockups, prototypes and demos that may not represent
   production-ready code.
 </p>
-
-{{#each views.sandbox.items}}
-  <article class="f-u-marginEnds">
-    <h4 class="f-Item-heading">
-      <a href="sandbox/{{@key}}.html">
-        {{toTitle name}}
-      </a>
-    </h4>
-    {{#if data.labels}}
-      <ul class="f-Item-labels f-u-listInline">
-        {{#each data.labels}}
-          <li>
-            <span class="f-Label f-Label--{{this}}">{{this}}</span>
-          </li>
-        {{/each}}
-      </ul>
-    {{/if}}
-    {{#if data.description}}
-      <p>{{{data.description}}}</p>
-    {{/if}}
-  </article>
-{{/each}}

--- a/test/fixtures/pages/components.html
+++ b/test/fixtures/pages/components.html
@@ -6,5 +6,4 @@ title: Components
 
 {{#each patterns.components.items}}
   foo
-  <!-- {{~> f-item this}} -->
 {{/each}}

--- a/test/index.js
+++ b/test/index.js
@@ -2,14 +2,18 @@
 var chai = require('chai');
 var config = require('./config');
 var expect = chai.expect;
-var builder = require('../dist/');
+var drizzle = require('../dist/');
 
 describe ('drizzle builder integration', () => {
   const options = config.fixtureOpts;
   it ('should return data and context',  () => {
-    return builder(options).then(allData => {
-      expect(allData.context).to.be.an('object');
-      expect(allData.templates).to.be.an('object');
+    return drizzle(options).then(drizzleData => {
+      expect(drizzleData.context).to.be.an('object');
+      expect(drizzleData.options).to.be.an('object');
+      expect(drizzleData.handlebars).to.be.an('object');
+      expect(drizzleData.context).to.contain.keys(
+        'pages', 'patterns', 'data', 'layouts'
+      );
       // TODO deeper tests as we go
     });
   });

--- a/test/index.js
+++ b/test/index.js
@@ -4,7 +4,7 @@ var config = require('./config');
 var expect = chai.expect;
 var drizzle = require('../dist/');
 
-describe ('drizzle builder integration', () => {
+describe.skip ('drizzle builder integration', () => {
   const options = config.fixtureOpts;
   it ('should return data and context',  () => {
     return drizzle(options).then(drizzleData => {

--- a/test/options.js
+++ b/test/options.js
@@ -7,6 +7,7 @@ var parseOptions = require('../dist/options');
 describe ('options', () => {
   var keys = [
     'data',
+    'dest',
     'handlebars',
     'helpers',
     'keys',

--- a/test/pages.js
+++ b/test/pages.js
@@ -5,10 +5,12 @@ var config = require('./config');
 
 var expect = chai.expect;
 var pages = require('../dist/pages');
-var drizzle = require('../dist');
 
 describe ('building pages', () => {
   it ('should build pages', () => {
-    
+    return config.prepare(config.fixtureOpts).then(pages)
+    .then(pageStructure => {
+      expect(pageStructure).to.be.an('object');
+    });
   });
 });

--- a/test/pages.js
+++ b/test/pages.js
@@ -9,8 +9,6 @@ var drizzle = require('../dist');
 
 describe ('building pages', () => {
   it ('should build pages', () => {
-    return drizzle(config.fixtureOpts).then(drizzleData => {
-      pages(drizzleData.options, drizzleData.context, drizzleData.templates);
-    });
+    
   });
 });

--- a/test/pages.js
+++ b/test/pages.js
@@ -9,8 +9,8 @@ var pages = require('../dist/pages');
 describe ('building pages', () => {
   it ('should build pages', () => {
     return config.prepareAll(config.fixtureOpts).then(pages)
-    .then(writePromises => {
-      console.log(writePromises);
+    .then(result => {
+      expect(result).to.be.true;
     });
   });
 });

--- a/test/pages.js
+++ b/test/pages.js
@@ -11,6 +11,7 @@ describe ('building pages', () => {
     return config.prepareAll(config.fixtureOpts).then(pages)
     .then(result => {
       expect(result).to.be.true;
+      // TODO: Many more tests
     });
   });
 });

--- a/test/pages.js
+++ b/test/pages.js
@@ -9,7 +9,8 @@ var pages = require('../dist/pages');
 describe ('building pages', () => {
   it ('should build pages', () => {
     return config.prepareAll(config.fixtureOpts).then(pages)
-    .then(pageStructure => {
+    .then(writePromises => {
+      console.log(writePromises);
     });
   });
 });

--- a/test/pages.js
+++ b/test/pages.js
@@ -1,0 +1,16 @@
+/* global describe, it */
+/* Integration testing for parse module */
+var chai = require('chai');
+var config = require('./config');
+
+var expect = chai.expect;
+var pages = require('../dist/pages');
+var drizzle = require('../dist');
+
+describe.only ('building pages', () => {
+  it ('should build pages', () => {
+    return drizzle(config.fixtureOpts).then(drizzleData => {
+      pages(drizzleData.options, drizzleData.context, drizzleData.templates);
+    });
+  });
+});

--- a/test/pages.js
+++ b/test/pages.js
@@ -8,9 +8,8 @@ var pages = require('../dist/pages');
 
 describe ('building pages', () => {
   it ('should build pages', () => {
-    return config.prepare(config.fixtureOpts).then(pages)
+    return config.prepareAll(config.fixtureOpts).then(pages)
     .then(pageStructure => {
-      expect(pageStructure).to.be.an('object');
     });
   });
 });

--- a/test/pages.js
+++ b/test/pages.js
@@ -7,7 +7,7 @@ var expect = chai.expect;
 var pages = require('../dist/pages');
 var drizzle = require('../dist');
 
-describe.only ('building pages', () => {
+describe ('building pages', () => {
   it ('should build pages', () => {
     return drizzle(config.fixtureOpts).then(drizzleData => {
       pages(drizzleData.options, drizzleData.context, drizzleData.templates);

--- a/test/parse-all.js
+++ b/test/parse-all.js
@@ -17,7 +17,7 @@ describe ('all data parsing', () => {
         expect(dataObj).to.be.an('object').and.to.contain.keys(
           'pages', 'patterns', 'layouts');
         expect(dataObj.patterns).to.contain.keys('name', 'items');
-        expect(dataObj.pages).to.contain.keys('name', 'items');
+        expect(dataObj.pages).not.to.contain.keys('name', 'items');
         //config.logObj(dataObj.pages);
       });
     });

--- a/test/parse.js
+++ b/test/parse.js
@@ -82,7 +82,8 @@ describe ('parse', () => {
         expect(pageData.subfolder.subpage).to.contain.keys(
           'resourceType', 'outputPath', 'path'
         );
-        expect(pageData.subfolder.subpage.outputPath).to.equal('subfolder');
+        expect(pageData.subfolder.subpage.outputPath).to.equal(
+          'subfolder/subpage.html');
       });
     });
   });

--- a/test/parse.js
+++ b/test/parse.js
@@ -3,6 +3,7 @@ var chai = require('chai');
 var config = require('./config');
 var expect = chai.expect;
 var parse = require('../dist/parse');
+var parseOptions = require('../dist/options');
 
 describe ('parse', () => {
   const defaultParsers = config.parsers;
@@ -67,20 +68,22 @@ describe ('parse', () => {
   });
   describe ('parsing pages', () => {
     it ('should correctly build data object from pages', () => {
-      return parse.parseRecursive(config.fixturePath('pages/**/*'), 'pages',
-        { parsers: defaultParsers,
-          markdownFields: ['notes'] }
-      )
-        .then(pageData => {
-          expect(pageData).to.be.an('object');
-          expect(pageData).to.contain.keys('name', 'items');
-          expect(pageData.items).to.contain.keys(
-            '04-sandbox', 'index', 'doThis');
-          expect(pageData.items.doThis).to.be.an('object');
-          expect(pageData.items.doThis.contents).to.be.a('string');
-          expect(pageData.subfolder.items.subpage)
-            .to.be.an('object');
-        });
+      var opts = parseOptions(config.fixtureOpts);
+      return parse.parsePages(opts).then(pageData => {
+        expect(pageData).to.be.an('object');
+        expect(pageData).not.to.contain.keys('items');
+        expect(pageData).to.contain.keys(
+          'subfolder', '04-sandbox', 'components', 'doThis', 'index');
+        expect(pageData.components).to.contain.keys(
+          'title', 'resourceType', 'outputPath', 'path', 'contents'
+        );
+        expect(pageData.subfolder).not.to.contain.keys('resourceType');
+        expect(pageData.subfolder).to.contain.keys('subpage');
+        expect(pageData.subfolder.subpage).to.contain.keys(
+          'resourceType', 'outputPath', 'path'
+        );
+        expect(pageData.subfolder.subpage.outputPath).to.equal('subfolder');
+      });
     });
   });
 

--- a/test/prepare.js
+++ b/test/prepare.js
@@ -1,0 +1,25 @@
+/* global describe, it, before */
+var chai = require('chai');
+var config = require('./config');
+var expect = chai.expect;
+var parseOptions = require('../dist/options');
+var prepare = require('../dist/prepare');
+
+describe('prepare', () => {
+  describe ('prepare context for build', () => {
+    var options,
+      preparePromise;
+    before (() => {
+      options = parseOptions(config.fixtureOpts);
+      preparePromise = prepare(options);
+    });
+    it ('should construct a context object', () => {
+      return preparePromise.then(drizzleData => {
+        expect(drizzleData).to.contain.keys('context', 'handlebars');
+        expect(drizzleData.context).to.contain.keys(
+          'data', 'pages', 'patterns', 'layouts'
+        );
+      });
+    });
+  });
+});


### PR DESCRIPTION
What it does: parses files matching glob for `pages` against relevant parsers, builds relevant local and global contexts, compiles pages as Handlebars templates, writes output files (pages).

What it doesn't do (yet): Wrap resulting page files in a containing layout.

I wanted to submit a PR of the basic bits of this feature before it got _too_ huge.  As such, certain things are in TODO/loose state, including:

* Organization of several modules, which need to be broken into submodules
* Commenting, clarity
* Full suite of tests (basic tests are extant but need significant expansion)
* A few temporary-named functions as I re-orient some of the parsing functions

Next step is a widespread module cleanup, reorg of modules, testing, and then page wrapping in layouts.

We're in that "so much green" state of PRs; it might not be feasible to evaluate this in any deep/meaningful way, and I am OK with that for now :).

/cc @mrgerardorodriguez 