### PR TITLE
Feature patterns parsing

### DIFF
--- a/src/parse/index.js
+++ b/src/parse/index.js
@@ -1,4 +1,5 @@
 import parseData from './data';
+import parseLayouts from './layouts';
 import parsePages from './pages';
 import parsePatterns from './patterns';
 
@@ -6,12 +7,14 @@ function parseAll (options = {}) {
   return Promise.all([
     parseData(options),
     parsePages(options),
-    parsePatterns(options)
+    parsePatterns(options),
+    parseLayouts(options)
   ]).then(allData => {
     return {
       data    : allData[0],
       pages   : allData[1],
       patterns: allData[2],
+      layouts : allData[3],
       options : options
     };
   });

--- a/src/parse/layouts.js
+++ b/src/parse/layouts.js
@@ -1,0 +1,7 @@
+import * as utils from '../utils';
+
+function parseLayouts (options) {
+  return utils.readFilesKeyed(options.src.layouts, options);
+}
+
+export default parseLayouts;

--- a/src/parse/pages.js
+++ b/src/parse/pages.js
@@ -7,10 +7,9 @@ function parsePages (options) {
   return utils.readFiles(options.src.pages, options).then(fileData => {
     const relativeRoot = utils.commonRoot(fileData);
     fileData.forEach(pageFile => {
-      const entryKey   = utils.keyname(pageFile.path, { stripNumbers: false });
       const keys       = utils.relativePathArray(
         pageFile.path, relativeRoot);
-      utils.deepObj(keys, pageData)[entryKey] = parseUtils
+      utils.deepObj(keys, pageData)[utils.resourceKey(pageFile)] = parseUtils
         .parseLocalData(pageFile, options);
     });
     return pageData;

--- a/src/parse/patterns.js
+++ b/src/parse/patterns.js
@@ -9,23 +9,20 @@ function parsePatterns (options) {
   return utils.readFiles(options.src.patterns, options).then(fileData => {
     const relativeRoot = utils.commonRoot(fileData);
     fileData.forEach(patternFile => {
-      const entryKey = utils.keyname(patternFile.path, { stripNumbers: false });
-      const pathKeys = utils.relativePathArray(patternFile.path,
-        relativeRoot);
-      const patternEntry = utils.deepObj(pathKeys, patternData);
-
-      const idKeys = pathKeys.map(utils.keyname);
-      const pathKey = utils.keyname(patternFile.path);
-      const id = idKeys.concat(pathKey).join('.');
+      const patternEntry = utils.deepObj(
+        utils.relativePathArray(patternFile.path, relativeRoot),
+        patternData
+      );
 
       patternEntry.items = patternEntry.items || {};
-      patternEntry.items[entryKey] = Object.assign(
-        parseUtils.parseLocalData(patternFile, options),
-        patternFile,
-        {
-          id,
-          name: utils.titleCase(pathKey)
-        }
+      patternEntry
+        .items[utils.resourceKey(patternFile)] = parseUtils.parseLocalData(
+          patternFile,
+          options,
+          {
+            id: utils.resourceId(patternFile, relativeRoot, 'patterns'),
+            name: utils.titleCase(utils.keyname(patternFile.path))
+          }
       );
     });
     return patternData;

--- a/src/parse/utils.js
+++ b/src/parse/utils.js
@@ -6,17 +6,18 @@ import marked from 'marked';
  * create the right kind of context for the object. Process relevant fields
  * with markdown.
  */
-function parseLocalData (fileObj, options) {
+function parseLocalData (fileObj, options, extendedData = {}) {
   const mdFields = options.markdownFields || [];
   const localData = Object.assign({}, fileObj.data);
   // First, clean up data object by running markdown over relevant fields
   // TODO: This feels awkward here
+  // Move to render?
   mdFields.forEach(mdField => {
     if (localData[mdField]) {
       localData[mdField] = marked(localData[mdField]);
     }
   });
-  fileObj = Object.assign(localData, fileObj);
+  fileObj = Object.assign(localData, fileObj, extendedData);
   return fileObj;
 }
 

--- a/src/prepare/partials.js
+++ b/src/prepare/partials.js
@@ -7,6 +7,7 @@ import * as utils from '../utils';
 function preparePartials (Handlebars, partials = '') {
   return utils.readFiles(partials).then(partialFiles => {
     partialFiles.forEach(partialFile => {
+      // TODO: Wow, no, need IDs
       const partialKey = utils.keyname(partialFile.path);
       Handlebars.registerPartial(partialKey, partialFile.contents);
     });

--- a/src/prepare/patterns.js
+++ b/src/prepare/patterns.js
@@ -1,0 +1,19 @@
+import * as utils from '../utils';
+/**
+ * Register a glob of partials.
+ * @param {Object} Handlebars instance
+ * @param {String || Array} glob
+ */
+function preparePatterns (Handlebars, patterns = '') {
+  return utils.readFiles(patterns).then(patternFiles => {
+    const relativeRoot = utils.commonRoot(patternFiles);
+    patternFiles.forEach(patternFile => {
+      const partialKey = utils.resourceId(
+        patternFile, relativeRoot, 'patterns');
+      Handlebars.registerPartial(partialKey, patternFile.contents);
+    });
+    return Handlebars.partials;
+  });
+}
+
+export default preparePatterns;

--- a/src/prepare/templates.js
+++ b/src/prepare/templates.js
@@ -1,6 +1,7 @@
 import preparePartials from './partials';
 import prepareHelpers from './helpers';
 import prepareLayouts from './layouts';
+import preparePatterns from './patterns';
 
 /**
  * Register partials and helpers per opts
@@ -12,7 +13,8 @@ function prepareTemplates (opts) {
   return Promise.all([
     prepareHelpers(opts.handlebars, opts.helpers),
     prepareLayouts(opts.handlebars, opts.src.layouts),
-    preparePartials(opts.handlebars, opts.src.partials)
+    preparePartials(opts.handlebars, opts.src.partials),
+    preparePatterns(opts.handlebars, opts.src.patterns)
   ]).then(handlebarsInfo => {
     return opts;
   });

--- a/src/render/patterns.js
+++ b/src/render/patterns.js
@@ -13,7 +13,7 @@ import * as utils from '../utils';
  *                               Used to derive the collection's "name"
  */
 function renderPatternCollection (patterns, drizzleData, collectionKey) {
-  for (var individualPatternKey in patterns.items) {
+  for (const individualPatternKey in patterns.items) {
     // We want to render only pattern-collection pages, not individual
     // patterns. Remove `contents` from individual patterns so the write
     // phase doesn't create files for them.
@@ -37,7 +37,7 @@ function renderPatternCollection (patterns, drizzleData, collectionKey) {
  * @return {Object} drizzleData All drizzleData
  */
 function walkPatterns (patterns, drizzleData, currentKey = 'patterns') {
-  for (var patternKey in patterns) {
+  for (const patternKey in patterns) {
     if (patternKey === 'items') {
       renderPatternCollection(patterns, drizzleData, currentKey);
     } else {

--- a/src/render/patterns.js
+++ b/src/render/patterns.js
@@ -4,17 +4,10 @@ import * as renderUtils from './utils';
  *
  */
 function renderPatternCollection (patterns, drizzleData, collectionKey) {
-  patterns.contents = renderUtils.applyTemplate(`
-    {{#extend "default"}}
-      {{#content "body"}}
-        {{#each items}}
-          {{id}}
-        {{/each}}
-      {{/content}}
-    {{/extend}}`,
+  patterns.contents = renderUtils.applyTemplate(
+    drizzleData.layouts.patternCollection.contents, // TODO obviously fragile
     renderUtils.localContext(patterns, drizzleData),
     drizzleData.options);
-  // console.log(patterns.contents);
 }
 
 /**

--- a/src/render/patterns.js
+++ b/src/render/patterns.js
@@ -1,0 +1,38 @@
+import * as renderUtils from './utils';
+
+/**
+ *
+ */
+function renderPatternCollection (patterns, drizzleData, collectionKey) {
+  patterns.contents = renderUtils.applyTemplate(`
+    {{#extend "default"}}
+      {{#content "body"}}
+        {{#each items}}
+          {{id}}
+        {{/each}}
+      {{/content}}
+    {{/extend}}`,
+    renderUtils.localContext(patterns, drizzleData),
+    drizzleData.options);
+  // console.log(patterns.contents);
+}
+
+/**
+ *
+ */
+function walkPatterns (patterns, drizzleData, currentKey = 'patterns') {
+  for (var patternKey in patterns) {
+    if (patternKey === 'items') {
+      renderPatternCollection(patterns, drizzleData, currentKey);
+    } else {
+      walkPatterns(patterns[patternKey], drizzleData, patternKey);
+    }
+  }
+  return drizzleData;
+}
+
+function renderPatterns (drizzleData) {
+  return walkPatterns(drizzleData.patterns, drizzleData);
+}
+
+export default renderPatterns;

--- a/src/render/patterns.js
+++ b/src/render/patterns.js
@@ -1,9 +1,25 @@
 import * as renderUtils from './utils';
+import * as utils from '../utils';
 
 /**
+ * For any given `patterns` entry, render a pattern-collection page for
+ * its `items`. Also, remove the `contents` property for individual patterns.
+ * Patterns will not render individual pages. This function mutates `patterns`.
  *
+ * @param {Object} patterns      The current level of the patterns tree we're
+ *                               rendering
+ * @param {Object} drizzleData   All the data we have, including `options`
+ * @param {String} collectionKey The key of the current set of `patterns`.
+ *                               Used to derive the collection's "name"
  */
 function renderPatternCollection (patterns, drizzleData, collectionKey) {
+  for (var individualPatternKey in patterns.items) {
+    // We want to render only pattern-collection pages, not individual
+    // patterns. Remove `contents` from individual patterns so the write
+    // phase doesn't create files for them.
+    delete patterns.items[individualPatternKey].contents;
+  }
+  patterns.name = utils.titleCase(utils.keyname(collectionKey));
   patterns.contents = renderUtils.applyTemplate(
     drizzleData.layouts.patternCollection.contents, // TODO obviously fragile
     renderUtils.localContext(patterns, drizzleData),
@@ -11,7 +27,14 @@ function renderPatternCollection (patterns, drizzleData, collectionKey) {
 }
 
 /**
+ * Recursively walk through the patterns data object and render content
+ * for "pattern collections" (any entry in `patterns` that contains an
+ * `items` property).
  *
+ * @param {Object} patterns     The current level of the `patterns` object.
+ * @param {Object} drizzleData
+ * @param {String} currentKey   The key for the current `patterns` object.
+ * @return {Object} drizzleData All drizzleData
  */
 function walkPatterns (patterns, drizzleData, currentKey = 'patterns') {
   for (var patternKey in patterns) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -261,6 +261,39 @@ function relativePathArray (filePath, fromPath) {
 }
 
 /**
+ * Generate a resourceId for a file. Use file.path and base the
+ * ID elements on the path elements between relativeRoot and file. Path
+ * elements will have special characters removed.
+ * @example resourceId(
+ *  '/foo/bar/baz/ole/01-fun-times.hbs', '/foo/bar/baz/', 'patterns'
+ * ); // -> patterns.ole.fun-times
+ * @param {Object}    Object representing file. Needs to have a `path` property
+ * @param {String} || {Array} relativeRoot path to relative root or path
+ *                            elements to same in Array
+ * @param {String} resourceCollection  Will be prepended as first element in ID
+ * @return {String} ID for this resource
+ */
+function resourceId (resourceFile, relativeRoot, resourceCollection) {
+  const pathKeys = relativePathArray(resourceFile.path, relativeRoot)
+    .map(keyname);
+  return [resourceCollection]
+    .concat(pathKeys)
+    .concat([keyname(resourceFile.path)])
+    .join ('.');
+}
+
+/**
+ * Convenience function to create proper variant of file's basename for
+ * use as a key in a data object.
+ * @example resourceKey({ path: '/foo/bar/baz/04-fun' }); // -> '04-fun'
+ * @param {Object} resourceFile Object representing a file. Needs `path` prop
+ * @return {String}
+ */
+function resourceKey (resourceFile) {
+  return keyname(resourceFile.path, { stripNumbers: false });
+}
+
+/**
  * Convert str to title case (every word will be capitalized)
  * @param {String} str
  * @return {String}
@@ -285,5 +318,7 @@ export { commonRoot,
          readFiles,
          readFilesKeyed,
          relativePathArray,
+         resourceId,
+         resourceKey,
          titleCase
        };

--- a/test/fixtures/layouts/patternCollection.html
+++ b/test/fixtures/layouts/patternCollection.html
@@ -1,0 +1,7 @@
+{{#extend "default"}}
+  {{#content "body"}}
+    {{#each items}}
+      {{@key}}
+    {{/each}}
+  {{/content}}
+{{/extend}}

--- a/test/fixtures/layouts/patternCollection.html
+++ b/test/fixtures/layouts/patternCollection.html
@@ -1,5 +1,6 @@
 {{#extend "default"}}
   {{#content "body"}}
+    <h2>{{name}}</h2>
     {{#each items}}
       {{@key}}
     {{/each}}

--- a/test/fixtures/patterns/typography/headings/base.html
+++ b/test/fixtures/patterns/typography/headings/base.html
@@ -1,0 +1,13 @@
+---
+name: Average Joe
+notes: |
+  [Link to Something](http://www.example.com)
+links:
+  Anchors, Buttons and Accessibility: http://formidable.com/blog/2014/05/08/anchors-buttons-and-accessibility/
+  When to Use the Button Element: https://css-tricks.com/use-button-element/
+---
+
+<h1>{{name}}</h1>
+
+<h1>I am a heading</h1>
+<h2>I am a smaller heading</h2>

--- a/test/parse/index.js
+++ b/test/parse/index.js
@@ -9,7 +9,7 @@ describe('parse/index (parseAll)', () => {
     var opts = config.parseOptions(config.fixtureOpts);
     return parseAll(opts).then(allData => {
       expect(allData).to.be.an('object').and.to.have
-        .keys('data', 'pages', 'patterns', 'options');
+        .keys('data', 'pages', 'patterns', 'options', 'layouts');
     });
   });
 });

--- a/test/parse/layouts.js
+++ b/test/parse/layouts.js
@@ -1,0 +1,14 @@
+/* global describe, it */
+var chai = require('chai');
+var config = require('../config');
+var expect = chai.expect;
+var parseLayouts = require('../../dist/parse/layouts');
+
+describe('parse/layouts', () => {
+  var opts = config.parseOptions(config.fixtureOpts);
+  it ('should parse and organize layouts', () => {
+    return parseLayouts(opts).then(layoutsData => {
+      expect(layoutsData).to.contain.keys('patternCollection', 'default');
+    });
+  });
+});

--- a/test/parse/patterns.js
+++ b/test/parse/patterns.js
@@ -9,7 +9,8 @@ describe('parse/patterns', () => {
   it ('should correctly build data object from patterns', () => {
     return parsePatterns(opts).then(patternData => {
       expect(patternData).to.be.an('object');
-      expect(patternData).to.have.keys('items', '01-fingers', 'components');
+      expect(patternData).to.have.keys(
+        'items', '01-fingers', 'components', 'typography');
       expect(patternData.items).to.have.keys('pink');
     });
   });

--- a/test/parse/patterns.js
+++ b/test/parse/patterns.js
@@ -5,12 +5,22 @@ var expect = chai.expect;
 var parsePatterns = require('../../dist/parse/patterns');
 
 describe('parse/patterns', () => {
+  var opts = config.parseOptions(config.fixtureOpts);
   it ('should correctly build data object from patterns', () => {
-    var opts = config.parseOptions(config.fixtureOpts);
     return parsePatterns(opts).then(patternData => {
       expect(patternData).to.be.an('object');
       expect(patternData).to.have.keys('items', '01-fingers', 'components');
       expect(patternData.items).to.have.keys('pink');
+    });
+  });
+  it ('should derive correct IDs for patterns', () => {
+    return parsePatterns(opts).then(patternData => {
+      expect(patternData.items.pink).to.include.key('id');
+      expect(patternData.items.pink.id).to.equal('patterns.pink');
+      expect(patternData.components.items.orange).to.include.key('id');
+      expect(patternData.components.items.orange.id).to.equal(
+        'patterns.components.orange'
+      );
     });
   });
   it ('should have more tests');

--- a/test/prepare/index.js
+++ b/test/prepare/index.js
@@ -31,4 +31,13 @@ describe ('prepare/index', () => {
       expect(preparedOpts.handlebars.partials).to.contain.keys('default');
     });
   });
+  it ('should prepare pattern partials', () => {
+    return prepare(opts).then(preparedOpts => {
+      expect(preparedOpts.handlebars.partials).to.contain.keys(
+        'patterns.pink',
+        'patterns.components.button.base',
+        'patterns.components.button.color-variation'
+      );
+    });
+  });
 });

--- a/test/prepare/layouts.js
+++ b/test/prepare/layouts.js
@@ -8,7 +8,7 @@ var prepareLayouts = require('../../dist/prepare/layouts');
 describe ('prepare/layouts', () => {
   const opts = options(config.fixtureOpts);
   before (() => {
-    return prepareLayouts(opts.handlebars, opts.layouts);
+    return prepareLayouts(opts.handlebars, opts.src.layouts);
   });
   it ('should register layouts as partials', () => {
     expect(opts.handlebars.partials).to.contain.keys('default');

--- a/test/prepare/patterns.js
+++ b/test/prepare/patterns.js
@@ -1,0 +1,21 @@
+/* global describe, it, before */
+var chai = require('chai');
+var config = require('../config');
+var expect = chai.expect;
+var options = require('../../dist/options');
+var preparePatterns = require('../../dist/prepare/patterns');
+
+describe ('prepare/patterns', () => {
+  const opts = options(config.fixtureOpts);
+  before (() => {
+    return preparePatterns(opts.handlebars, opts.src.patterns);
+  });
+  it ('should register patterns as partials', () => {
+    expect(opts.handlebars.partials).to.contain.keys(
+      'patterns.pink',
+      'patterns.components.button.base',
+      'patterns.components.button.color-variation'
+    );
+  });
+
+});

--- a/test/render/patterns.js
+++ b/test/render/patterns.js
@@ -15,20 +15,7 @@ describe ('render/patterns', () => {
   });
   it ('should have data', () => {
     allData.then(drizzleData => {
-    //  config.logObj(drizzleData.patterns);
+      config.logObj(drizzleData.patterns);
     });
   });
-  // it ('should compile templates', () => {
-  //   return allData.then(drizzleData => {
-  //     expect(drizzleData.pages['04-sandbox'].contents)
-  //       .to.have.string('<h1>Sandbox</h1>');
-  //   });
-  // });
-  // it ('should override layouts when told to', () => {
-  //   return allData.then(drizzleData => {
-  //     const customPage = drizzleData.pages.doThis;
-  //     expect(customPage.contents).to.contain('This is the Page Layout');
-  //     expect(customPage.contents).to.contain('<h2>foobar</h2>');
-  //   });
-  // });
 });

--- a/test/render/patterns.js
+++ b/test/render/patterns.js
@@ -13,9 +13,47 @@ describe ('render/patterns', () => {
     allData =  prepare(opts).then(parse).then(renderPatterns);
     return allData;
   });
-  it ('should have data', () => {
-    allData.then(drizzleData => {
-      config.logObj(drizzleData.patterns);
+  it ('should return patterns data', () => {
+    return allData.then(drizzleData => {
+      expect(drizzleData.patterns).to.be.an('object');
+      expect(drizzleData.patterns).to.contain.keys(
+        'items', 'contents', 'components');
     });
   });
+  it ('should remove contents from individual patterns', () => {
+    return allData.then(drizzleData => {
+      expect(drizzleData.patterns.items).to.be.an('object');
+      expect(drizzleData.patterns.items.pink).to.be.an('object');
+      expect(drizzleData.patterns.items.pink).not.to.have.key('contents');
+      expect(drizzleData.patterns.items.pink).to.contain.key('id');
+    });
+  });
+  it ('should provide contents for pattern collections', () => {
+    return allData.then(drizzleData => {
+      expect(drizzleData.patterns).to.contain.keys('contents');
+      expect(drizzleData.patterns['01-fingers']).to.contain.keys('contents');
+      expect(drizzleData.patterns.components).to.contain.keys('contents');
+      // `typography` doesn't have any immediate-child pattern files
+      expect(drizzleData.patterns.typography).not.to.contain.key('contents');
+    });
+  });
+  it ('should add a name property for collections', () => {
+    return allData.then(drizzleData => {
+      expect(drizzleData.patterns).to.contain.keys('contents');
+      expect(drizzleData.patterns.name).to.equal('Patterns');
+      expect(drizzleData.patterns['01-fingers']).to.contain.keys('name');
+      expect(drizzleData.patterns['01-fingers'].name).to.equal('Fingers');
+    });
+  });
+  it ('should render pattern collections with proper context', () => {
+    return allData.then(drizzleData => {
+      expect(drizzleData.patterns.typography).to.be.an('object');
+      expect(drizzleData.patterns.typography.headings).to.be.an('object');
+      expect(drizzleData.patterns.typography.headings)
+        .to.contain.keys('contents');
+      // expect(drizzleData.patterns.typography.headings.contents)
+      //   .to.contain('<h1>Headings</h1>');
+    });
+  });
+
 });

--- a/test/render/patterns.js
+++ b/test/render/patterns.js
@@ -1,0 +1,34 @@
+/* global describe, it, before */
+var chai = require('chai');
+var config = require('../config');
+var expect = chai.expect;
+var prepare = require('../../dist/prepare/');
+var parse = require('../../dist/parse/');
+var renderPatterns = require('../../dist/render/patterns');
+
+describe ('render/patterns', () => {
+  var opts, allData;
+  before (() => {
+    opts = config.parseOptions(config.fixtureOpts);
+    allData =  prepare(opts).then(parse).then(renderPatterns);
+    return allData;
+  });
+  it ('should have data', () => {
+    allData.then(drizzleData => {
+    //  config.logObj(drizzleData.patterns);
+    });
+  });
+  // it ('should compile templates', () => {
+  //   return allData.then(drizzleData => {
+  //     expect(drizzleData.pages['04-sandbox'].contents)
+  //       .to.have.string('<h1>Sandbox</h1>');
+  //   });
+  // });
+  // it ('should override layouts when told to', () => {
+  //   return allData.then(drizzleData => {
+  //     const customPage = drizzleData.pages.doThis;
+  //     expect(customPage.contents).to.contain('This is the Page Layout');
+  //     expect(customPage.contents).to.contain('<h2>foobar</h2>');
+  //   });
+  // });
+});

--- a/test/utils.js
+++ b/test/utils.js
@@ -185,6 +185,28 @@ describe ('utils', () => {
       });
     });
   });
+  describe('resourceId', () => {
+    it ('should generate a prefixed resourceId', () => {
+      var pseudoFile = { path: '/foo/bar/baz/ding/dong.txt' };
+      var pseudoRoot = '/foo/bar/baz';
+      var resourceId = utils.resourceId(pseudoFile, pseudoRoot, 'pattern');
+      expect(resourceId).to.equal('pattern.ding.dong');
+    });
+    it ('should correctly remove special characters from IDs', () => {
+      var pseudoFile = { path: '/foo/bar/baz/03-ding/04-dong.txt' };
+      var pseudoRoot = '/foo/bar/baz';
+      var resourceId = utils.resourceId(pseudoFile, pseudoRoot, 'patterns');
+      expect(resourceId).to.equal('patterns.ding.dong');
+    });
+  });
+  describe('resourceKey', () => {
+    it ('should generate the right key for a file', () => {
+      var resourceKey = utils.resourceKey(
+        { path: '/foo/bar/baz/05-dingle.txt' }
+      );
+      expect(resourceKey).to.equal('05-dingle');
+    });
+  });
   describe('dirname functions', () => {
     describe('parentDirname', () => {
       it ('should derive correct parent dirname', () => {


### PR DESCRIPTION
Hi! This PR introduces some features around `rendering` `patterns`, that is, constructing an object that represents what should ultimately be output as HTML pages. It does not handle the actual writing to the file system yet; to keep this PR from getting too huge I'd like to do that separately.

The main point: a directory under the main `patterns` directory that contains direct-descendent pattern files is considered a `collection` and will generate an output HTML page using a template that can iterate over the collection's patterns and output them. This PR handles the rendering part of that—compiling the right templates with the right context—but not the filesystem output yet.

When reviewing this, it may be helpful to know/remember that `drizzle` executes in four _phases_:

* `prepare` — Primarily concerned with templating prep—parsing and registering partials and helpers and whatnot
* `parse` — Parse and process different kinds of source files (patterns, data, pages...)
* `render` — Compile templates and build objects that represent output
* `write` — Write rendered resources to fs

This PR is primarily concerned with the `render` phase for `patterns` but extends some other areas as needed to support that.

Here are some things in this PR:
* Adds layout parsing to the `prepare` step — this registers layouts as partials. Necessary for `handlebars-layouts` and other reasons.
* Adjusts the `parse` step for `patterns`
* Adjusts the `parseLocalData` function (tweaks precedence of different data sources for a given resource)
* Adds a `render` module for `patterns`. Solidifies the notion of `pattern` `collections`
* Adds a `prepare` step for `patterns` to register each as a `partial`
* Adds and adjusts some functions in `utils` related to object organization and resource IDs
* Adds the notion of a `patternCollection` template (name may change to be simpler) used to render collections of patterns. Also adds fixtures for same.
* Adds additional fixtures and a bunch of tests.

/cc @tylersticka @erikjung 