### PR TITLE
Feature: Write Pattern Collections to FS

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
     "babel-plugin-transform-es2015-modules-commonjs-simple": "^1.0.2",
     "babel-preset-es2015": "^6.5.0",
     "chai": "^3.5.0",
-    "chai-fs": "^0.1.0",
     "eslint": "^2.2.0",
-    "mocha": "^2.4.5"
+    "mocha": "^2.4.5",
+    "rimraf": "^2.5.2"
   }
 }

--- a/src/parse/patterns.js
+++ b/src/parse/patterns.js
@@ -9,12 +9,15 @@ function parsePatterns (options) {
   return utils.readFiles(options.src.patterns, options).then(fileData => {
     const relativeRoot = utils.commonRoot(fileData);
     fileData.forEach(patternFile => {
+      // Retrieve the correct object reference where we should put this
+      // pattern. This represents the "collection" containing this pattern.
       const patternEntry = utils.deepObj(
         utils.relativePathArray(patternFile.path, relativeRoot),
         patternData
       );
-
+      // Create the special `items` property (object) if not extant
       patternEntry.items = patternEntry.items || {};
+      // Each pattern is added to the `items` object of its parent collection
       patternEntry
         .items[utils.resourceKey(patternFile)] = parseUtils.parseLocalData(
           patternFile,

--- a/src/render/index.js
+++ b/src/render/index.js
@@ -1,7 +1,19 @@
 import renderPages from './pages';
+import renderPatterns from './patterns';
 
 function render (drizzleData) {
-  return renderPages(drizzleData);
+  return Promise.all([
+    renderPages(drizzleData),
+    renderPatterns(drizzleData)
+  ]).then(allData => {
+    return {
+      data    : drizzleData.data,
+      pages   : allData[0],
+      patterns: allData[1],
+      layouts : drizzleData.layouts,
+      options : drizzleData.options
+    };
+  });
 }
 
 export default render;

--- a/src/render/pages.js
+++ b/src/render/pages.js
@@ -55,7 +55,7 @@ function walkPages (pages, drizzleData) {
   for (var pageKey in pages) {
     walkPages(pages[pageKey], drizzleData);
   }
-  return drizzleData;
+  return drizzleData.pages;
 }
 
 function renderPages (drizzleData) {

--- a/src/render/patterns.js
+++ b/src/render/patterns.js
@@ -13,14 +13,13 @@ import * as utils from '../utils';
  *                               Used to derive the collection's "name"
  */
 function renderPatternCollection (patterns, drizzleData, collectionKey) {
-  const collectionContents = renderUtils.applyTemplate(
+  patterns.collection = {
+    name: utils.titleCase(utils.keyname(collectionKey))
+  };
+  patterns.collection.contents = renderUtils.applyTemplate(
     drizzleData.layouts.patternCollection.contents, // TODO obviously fragile
     renderUtils.localContext(patterns, drizzleData),
     drizzleData.options);
-  patterns.collection = {
-    contents: collectionContents,
-    name: utils.titleCase(utils.keyname(collectionKey))
-  };
   return patterns;
 }
 

--- a/src/render/patterns.js
+++ b/src/render/patterns.js
@@ -44,7 +44,7 @@ function walkPatterns (patterns, drizzleData, currentKey = 'patterns') {
       walkPatterns(patterns[patternKey], drizzleData, patternKey);
     }
   }
-  return drizzleData;
+  return drizzleData.patterns;
 }
 
 function renderPatterns (drizzleData) {

--- a/src/render/patterns.js
+++ b/src/render/patterns.js
@@ -13,17 +13,15 @@ import * as utils from '../utils';
  *                               Used to derive the collection's "name"
  */
 function renderPatternCollection (patterns, drizzleData, collectionKey) {
-  for (const individualPatternKey in patterns.items) {
-    // We want to render only pattern-collection pages, not individual
-    // patterns. Remove `contents` from individual patterns so the write
-    // phase doesn't create files for them.
-    delete patterns.items[individualPatternKey].contents;
-  }
-  patterns.name = utils.titleCase(utils.keyname(collectionKey));
-  patterns.contents = renderUtils.applyTemplate(
+  const collectionContents = renderUtils.applyTemplate(
     drizzleData.layouts.patternCollection.contents, // TODO obviously fragile
     renderUtils.localContext(patterns, drizzleData),
     drizzleData.options);
+  patterns.collection = {
+    contents: collectionContents,
+    name: utils.titleCase(utils.keyname(collectionKey))
+  };
+  return patterns;
 }
 
 /**

--- a/src/write/patterns.js
+++ b/src/write/patterns.js
@@ -1,0 +1,61 @@
+import path from 'path';
+import { write } from './utils';
+
+/**
+ * Figure out the output path for `page` and write it to the filesystem.
+ * @TODO options.keys is still dumb
+ * @TODO hard-coded `.html` OK?
+ *
+ * @param {Object} collection         Will be mutated
+ * @param {Object} drizzleData
+ * @param {Array} entryKeys           path components
+ * @return {Promise} for file write
+ */
+function writePattern (collection, drizzleData, entryKeys) {
+  const fileKey = entryKeys.pop();
+  const outputPath = path.join(entryKeys.join(path.sep), fileKey + '.html');
+  const fullPath = path.normalize(path.join(
+    drizzleData.options.dest,
+    drizzleData.options.destPaths.patterns,
+    outputPath));
+  collection.outputPath = fullPath;
+  return write(fullPath, collection.contents);
+}
+
+/**
+ * Traverse pages object and write out any page objects to files. An object
+ * is considered a page if it has a `contents` property.
+ *
+ * @param {Object} pages   current level of pages tree
+ * @param {Object} drizzleData
+ * @param {String} currentKey  This is a bit inelegant, but we need to keep
+ *                             track of the current object's key in the owning
+ *                             object because it will be part of the filename(s)
+ * @param {Array} writePromises All write promises so far
+ * @return {Array} of Promises
+ */
+function walkPatterns (patterns, drizzleData,
+  currentKeys = [], writePromises = []) {
+  if (patterns.contents) {
+    return writePattern(patterns, drizzleData, currentKeys);
+  }
+  for (const patternKey in patterns) {
+    currentKeys.push(patternKey);
+    writePromises = writePromises.concat(
+      walkPatterns(patterns[patternKey],
+        drizzleData, currentKeys, writePromises));
+  }
+  return writePromises;
+}
+
+/**
+ * TODO: Comment, etc.
+ */
+function writePatterns (drizzleData) {
+  return Promise.all(walkPatterns(drizzleData.patterns, drizzleData))
+    .then(() => {
+      return drizzleData;
+    });
+}
+
+export default writePatterns;

--- a/test/fixtures/layouts/patternCollection.html
+++ b/test/fixtures/layouts/patternCollection.html
@@ -1,6 +1,6 @@
 {{#extend "default"}}
   {{#content "body"}}
-    <h2>{{name}}</h2>
+    <h2>{{collection.name}}</h2>
     {{#each items}}
       {{@key}}
     {{/each}}

--- a/test/index.js
+++ b/test/index.js
@@ -1,9 +1,15 @@
-/* global describe, it */
+/* global describe, it, before */
 var chai = require('chai');
 var config = require('./config');
 var expect = chai.expect;
 var drizzle = require('../dist/');
+var Promise = require('bluebird');
+var rimraf = Promise.promisify(require('rimraf'));
 
+before (() => {
+  // Delete all output files
+  return rimraf(config.fixtureOpts.dest);
+});
 describe ('drizzle', () => {
   const options = config.fixtureOpts;
   it ('should return data',  () => {

--- a/test/parse/patterns.js
+++ b/test/parse/patterns.js
@@ -4,7 +4,7 @@ var config = require('../config');
 var expect = chai.expect;
 var parsePatterns = require('../../dist/parse/patterns');
 
-describe('parse/patterns', () => {
+describe ('parse/patterns', () => {
   var opts = config.parseOptions(config.fixtureOpts);
   it ('should correctly build data object from patterns', () => {
     return parsePatterns(opts).then(patternData => {
@@ -24,5 +24,11 @@ describe('parse/patterns', () => {
       );
     });
   });
-  it ('should have more tests');
+  it ('should add relevant properties to individual pattern objects', () => {
+    return parsePatterns(opts).then(patternData => {
+      expect(patternData.items.pink).to.be.an('object');
+      expect(patternData.items.pink).to.contain.keys(
+        'name', 'id', 'contents', 'path', 'data');
+    });
+  });
 });

--- a/test/render/index.js
+++ b/test/render/index.js
@@ -1,0 +1,25 @@
+/* global describe, it, before */
+var chai = require('chai');
+var config = require('../config');
+var expect = chai.expect;
+var prepare = require('../../dist/prepare/');
+var parse = require('../../dist/parse/');
+var renderAll = require('../../dist/render/');
+
+describe ('render/index (renderAll)', () => {
+  var opts, allData;
+  before (() => {
+    opts = config.parseOptions(config.fixtureOpts);
+    allData = prepare(opts).then(parse).then(renderAll);
+  });
+  it ('should correctly build composite data object', () => {
+    return allData.then(drizzleData => {
+      expect(drizzleData).to.be.an('object').and.to.have
+        .keys('data', 'pages', 'patterns', 'options', 'layouts');
+      expect(drizzleData.pages).to.contain.keys('components', 'doThis');
+      expect(drizzleData.patterns).to.contain.keys('01-fingers', 'components');
+      expect(drizzleData.data).to.contain.keys('data-as-json');
+      expect(drizzleData.layouts).to.contain.keys('default', 'page');
+    });
+  });
+});

--- a/test/render/pages.js
+++ b/test/render/pages.js
@@ -14,14 +14,14 @@ describe ('render/pages', () => {
     return allData;
   });
   it ('should compile templates', () => {
-    return allData.then(drizzleData => {
-      expect(drizzleData.pages['04-sandbox'].contents)
+    return allData.then(pageData => {
+      expect(pageData['04-sandbox'].contents)
         .to.have.string('<h1>Sandbox</h1>');
     });
   });
   it ('should override layouts when told to', () => {
-    return allData.then(drizzleData => {
-      const customPage = drizzleData.pages.doThis;
+    return allData.then(pageData => {
+      const customPage = pageData.doThis;
       expect(customPage.contents).to.contain('This is the Page Layout');
       expect(customPage.contents).to.contain('<h2>foobar</h2>');
     });

--- a/test/render/patterns.js
+++ b/test/render/patterns.js
@@ -44,6 +44,7 @@ describe ('render/patterns', () => {
       expect(patternData.typography.headings).to.be.an('object');
       expect(patternData.typography.headings)
         .to.contain.keys('collection');
+      expect(patternData.collection.contents).to.contain('<h2>Patterns</h2>');
       // expect(drizzleData.patterns.typography.headings.contents)
       //   .to.contain('<h1>Headings</h1>');
     });

--- a/test/render/patterns.js
+++ b/test/render/patterns.js
@@ -14,42 +14,42 @@ describe ('render/patterns', () => {
     return allData;
   });
   it ('should return patterns data', () => {
-    return allData.then(drizzleData => {
-      expect(drizzleData.patterns).to.be.an('object');
-      expect(drizzleData.patterns).to.contain.keys(
+    return allData.then(patternData => {
+      expect(patternData).to.be.an('object');
+      expect(patternData).to.contain.keys(
         'items', 'contents', 'components');
     });
   });
   it ('should remove contents from individual patterns', () => {
-    return allData.then(drizzleData => {
-      expect(drizzleData.patterns.items).to.be.an('object');
-      expect(drizzleData.patterns.items.pink).to.be.an('object');
-      expect(drizzleData.patterns.items.pink).not.to.have.key('contents');
-      expect(drizzleData.patterns.items.pink).to.contain.key('id');
+    return allData.then(patternData => {
+      expect(patternData.items).to.be.an('object');
+      expect(patternData.items.pink).to.be.an('object');
+      expect(patternData.items.pink).not.to.have.key('contents');
+      expect(patternData.items.pink).to.contain.key('id');
     });
   });
   it ('should provide contents for pattern collections', () => {
-    return allData.then(drizzleData => {
-      expect(drizzleData.patterns).to.contain.keys('contents');
-      expect(drizzleData.patterns['01-fingers']).to.contain.keys('contents');
-      expect(drizzleData.patterns.components).to.contain.keys('contents');
+    return allData.then(patternData => {
+      expect(patternData).to.contain.keys('contents');
+      expect(patternData['01-fingers']).to.contain.keys('contents');
+      expect(patternData.components).to.contain.keys('contents');
       // `typography` doesn't have any immediate-child pattern files
-      expect(drizzleData.patterns.typography).not.to.contain.key('contents');
+      expect(patternData.typography).not.to.contain.key('contents');
     });
   });
   it ('should add a name property for collections', () => {
-    return allData.then(drizzleData => {
-      expect(drizzleData.patterns).to.contain.keys('contents');
-      expect(drizzleData.patterns.name).to.equal('Patterns');
-      expect(drizzleData.patterns['01-fingers']).to.contain.keys('name');
-      expect(drizzleData.patterns['01-fingers'].name).to.equal('Fingers');
+    return allData.then(patternData => {
+      expect(patternData).to.contain.keys('contents');
+      expect(patternData.name).to.equal('Patterns');
+      expect(patternData['01-fingers']).to.contain.keys('name');
+      expect(patternData['01-fingers'].name).to.equal('Fingers');
     });
   });
   it ('should render pattern collections with proper context', () => {
-    return allData.then(drizzleData => {
-      expect(drizzleData.patterns.typography).to.be.an('object');
-      expect(drizzleData.patterns.typography.headings).to.be.an('object');
-      expect(drizzleData.patterns.typography.headings)
+    return allData.then(patternData => {
+      expect(patternData.typography).to.be.an('object');
+      expect(patternData.typography.headings).to.be.an('object');
+      expect(patternData.typography.headings)
         .to.contain.keys('contents');
       // expect(drizzleData.patterns.typography.headings.contents)
       //   .to.contain('<h1>Headings</h1>');

--- a/test/render/patterns.js
+++ b/test/render/patterns.js
@@ -17,32 +17,25 @@ describe ('render/patterns', () => {
     return allData.then(patternData => {
       expect(patternData).to.be.an('object');
       expect(patternData).to.contain.keys(
-        'items', 'contents', 'components');
+        'items', 'collection', 'components');
     });
   });
-  it ('should remove contents from individual patterns', () => {
+  it ('should provide metadata for pattern collections', () => {
     return allData.then(patternData => {
-      expect(patternData.items).to.be.an('object');
-      expect(patternData.items.pink).to.be.an('object');
-      expect(patternData.items.pink).not.to.have.key('contents');
-      expect(patternData.items.pink).to.contain.key('id');
-    });
-  });
-  it ('should provide contents for pattern collections', () => {
-    return allData.then(patternData => {
-      expect(patternData).to.contain.keys('contents');
-      expect(patternData['01-fingers']).to.contain.keys('contents');
-      expect(patternData.components).to.contain.keys('contents');
+      expect(patternData).to.contain.keys('collection');
+      expect(patternData['01-fingers']).to.contain.keys('collection');
+      expect(patternData.components.collection).to.contain.keys('contents');
       // `typography` doesn't have any immediate-child pattern files
-      expect(patternData.typography).not.to.contain.key('contents');
+      expect(patternData.typography).not.to.contain.key('collection');
     });
   });
   it ('should add a name property for collections', () => {
     return allData.then(patternData => {
-      expect(patternData).to.contain.keys('contents');
-      expect(patternData.name).to.equal('Patterns');
-      expect(patternData['01-fingers']).to.contain.keys('name');
-      expect(patternData['01-fingers'].name).to.equal('Fingers');
+      expect(patternData).not.to.contain.keys('contents');
+      expect(patternData.collection.name).to.equal('Patterns');
+      expect(patternData['01-fingers'].collection).to.contain.keys(
+        'name', 'contents');
+      expect(patternData['01-fingers'].collection.name).to.equal('Fingers');
     });
   });
   it ('should render pattern collections with proper context', () => {
@@ -50,7 +43,7 @@ describe ('render/patterns', () => {
       expect(patternData.typography).to.be.an('object');
       expect(patternData.typography.headings).to.be.an('object');
       expect(patternData.typography.headings)
-        .to.contain.keys('contents');
+        .to.contain.keys('collection');
       // expect(drizzleData.patterns.typography.headings.contents)
       //   .to.contain('<h1>Headings</h1>');
     });

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -1,0 +1,29 @@
+const fs = require('fs');
+const Promise = require('bluebird');
+const readFile = Promise.promisify(fs.readFile);
+const stat     = Promise.promisify(fs.stat);
+
+function areFiles (paths) {
+  return Promise.all(paths.map(isFile)).then(results => {
+    return !results.some(result => result === false);
+  });
+}
+
+function isFile (path) {
+  return stat(path).then(stats => {
+    if (stats.isFile()) {
+      return true;
+    }
+    return false;
+  }).catch(fail => false);
+}
+
+function fileContents (path) {
+  return readFile(path, 'utf-8');
+}
+
+module.exports = {
+  areFiles: areFiles,
+  fileContents: fileContents,
+  isFile: isFile
+};

--- a/test/write/pages.js
+++ b/test/write/pages.js
@@ -1,13 +1,13 @@
 /* global describe, it, before */
 var chai = require('chai');
 var expect = chai.expect;
-chai.use(require('chai-fs'));
 var config = require('../config');
 var prepare = require('../../dist/prepare/');
 var parse = require('../../dist/parse/');
 var render = require('../../dist/render/');
 var writePages = require('../../dist/write/pages');
 var options = require('../../dist/options');
+var testUtils = require('../test-utils');
 
 describe ('write/pages', () => {
   var opts = options(config.fixtureOpts);
@@ -17,20 +17,25 @@ describe ('write/pages', () => {
     return allData;
   });
   it ('should write page files', () => {
-    allData.then(drizzleData => {
-      //config.logObj(drizzleData.pages);
-      expect(drizzleData.pages.doThis.outputPath).to.be.a.file;
-      expect(drizzleData.pages['04-sandbox'].outputPath).to.be.a.file;
+    return allData.then(drizzleData => {
+      const paths = [
+        drizzleData.pages.doThis.outputPath,
+        drizzleData.pages['04-sandbox'].outputPath
+      ];
+      return testUtils.areFiles(paths).then(allAreFiles => {
+        expect(allAreFiles).to.be.true;
+      });
     });
   });
   it ('should write page files with compiled contents', () => {
     allData.then(drizzleData => {
-      expect(drizzleData.pages.doThis).to.have.content(
-        '<h1>This is the Page Layout</h1>');
-      expect(drizzleData.pages.doThis).to.have.content(
-        '<h2>foobar</h2>');
-      expect(drizzleData.pages.components).to.have.content(
-        '<div class="pattern">');
+      return testUtils.fileContents(drizzleData.pages.doThis.outputPath)
+      .then(contents => {
+        expect(contents).to.contain('<h2>foobar</h2>');
+        expect(contents).to.contain('<h1>This is the Page Layout</h1>');
+        expect(contents).not.to.contain('Body content should replace this.');
+      });
+
     });
   });
 });

--- a/test/write/patterns.js
+++ b/test/write/patterns.js
@@ -1,0 +1,26 @@
+/* global describe, it, before */
+var chai = require('chai');
+var expect = chai.expect;
+chai.use(require('chai-fs'));
+var config = require('../config');
+var prepare = require('../../dist/prepare/');
+var parse = require('../../dist/parse/');
+var render = require('../../dist/render/');
+var writePatterns = require('../../dist/write/patterns');
+var options = require('../../dist/options');
+
+describe.skip ('write/patterns', () => {
+  var opts = options(config.fixtureOpts);
+  var allData;
+  before (() => {
+    allData = prepare(opts).then(parse).then(render).then(writePatterns);
+    return allData;
+  });
+  describe ('determining output paths', () => {
+    it ('should add outputPath property to pattern collections', () => {
+      allData.then(drizzleData => {
+        config.logObj(drizzleData.patterns);
+      });
+    });
+  });
+});

--- a/test/write/patterns.js
+++ b/test/write/patterns.js
@@ -1,7 +1,6 @@
 /* global describe, it, before */
 var chai = require('chai');
 var expect = chai.expect;
-chai.use(require('chai-fs'));
 var config = require('../config');
 var prepare = require('../../dist/prepare/');
 var parse = require('../../dist/parse/');
@@ -9,18 +8,16 @@ var render = require('../../dist/render/');
 var writePatterns = require('../../dist/write/patterns');
 var options = require('../../dist/options');
 
-describe.skip ('write/patterns', () => {
+describe ('write/patterns', () => {
   var opts = options(config.fixtureOpts);
   var allData;
   before (() => {
-    allData = prepare(opts).then(parse).then(render).then(writePatterns);
+    allData = prepare(opts).then(parse).then(render);
     return allData;
   });
   describe ('determining output paths', () => {
     it ('should add outputPath property to pattern collections', () => {
-      allData.then(drizzleData => {
-        config.logObj(drizzleData.patterns);
-      });
+      return allData.then(writePatterns);
     });
   });
 });

--- a/test/write/patterns.js
+++ b/test/write/patterns.js
@@ -7,17 +7,28 @@ var parse = require('../../dist/parse/');
 var render = require('../../dist/render/');
 var writePatterns = require('../../dist/write/patterns');
 var options = require('../../dist/options');
+var testUtils = require('../test-utils');
 
 describe ('write/patterns', () => {
   var opts = options(config.fixtureOpts);
   var allData;
   before (() => {
-    allData = prepare(opts).then(parse).then(render);
+    allData = prepare(opts).then(parse).then(render).then(writePatterns);
     return allData;
   });
   describe ('determining output paths', () => {
-    it ('should add outputPath property to pattern collections', () => {
-      return allData.then(writePatterns);
+    it ('should write out the correct files', () => {
+      return allData.then(drizzleData => {
+        const outPaths = [
+          drizzleData.patterns.collection.outputPath,
+          drizzleData.patterns.components.collection.outputPath,
+          drizzleData.patterns.components.button.collection.outputPath
+        ];
+        return testUtils.areFiles(outPaths).then(result => {
+          expect(result).to.be.true;
+        });
+      });
     });
+    it ('should prefix with patterns prefix');
   });
 });


### PR DESCRIPTION
This PR introduces support for basic file output for pattern-collection pages. The next step will be to architect the `pattern` helper (analogous to the `material` helper) to embed patterns into pattern-collection pages in a more full-featured way. I also have some further work to do with massaging local context when compiling templates, but we're headed the right way.

This PR:

* Adds a `write/patterns` module for writing out the pattern-collections pages.
* Removes the borken `chai-fs` package, leaving no good option for third-party file-testing assertions. So I wrote some hokey basic file-checking utility functions in a new file `test/test-utils.js`.
* Adds `rimraf` dependency and use it to clear out `dist` in the `test` directory—that is, remove pre-existing test output before running test suites.
* Re-factors the `render/index` module to resolve to the right shape of object for chaining on to the `write` phase
* Adds a new `collection` object representing pattern-collection metadata.
* Adds tests for all the above.

/cc @erikjung @tylersticka 