### PR TITLE
Pattern helper and main context

### DIFF
--- a/src/defaults.js
+++ b/src/defaults.js
@@ -7,7 +7,7 @@ const defaults = {
     layouts : ['src/layouts/**/*'],
     pages   : ['src/pages/**/*'],
     partials: ['src/partials/**/*'],
-    patterns: ['src/patterns/**/*']
+    patterns: ['src/patterns/**/*.html']
   },
   dest          : 'dist',
   destPaths     : {

--- a/src/helpers/pattern.js
+++ b/src/helpers/pattern.js
@@ -1,4 +1,5 @@
 import * as utils from '../utils';
+import patternContext from '../render/context/pattern';
 
 function registerPatternHelper (Handlebars) {
   Handlebars.registerHelper('pattern', (id, rootContext, opts) => {
@@ -8,8 +9,7 @@ function registerPatternHelper (Handlebars) {
       return 'nope';
     }
     // Build a local context TODO Move this
-    const localContext = Object.assign({},
-      rootContext, patternObj, patternObj.data);
+    const localContext = patternContext(patternObj, rootContext);
 
     // Find and work with partial template
     let template = Handlebars.partials[id];

--- a/src/helpers/pattern.js
+++ b/src/helpers/pattern.js
@@ -4,12 +4,12 @@ import patternContext from '../render/context/pattern';
 function registerPatternHelper (Handlebars) {
   Handlebars.registerHelper('pattern', (id, rootContext, opts) => {
     // Retrieve pattern object from ID
-    const patternObj = utils.deepPattern(id, rootContext.patterns);
+    const patternObj = utils.deepPattern(id, rootContext.drizzle.patterns);
     if (!patternObj) { // TODO yeah: what then?
       return 'nope';
     }
     // Build a local context TODO Move this
-    const localContext = patternContext(patternObj, rootContext);
+    const localContext = patternContext(patternObj, rootContext.drizzle);
 
     // Find and work with partial template
     let template = Handlebars.partials[id];

--- a/src/helpers/pattern.js
+++ b/src/helpers/pattern.js
@@ -1,0 +1,27 @@
+import * as utils from '../utils';
+
+function registerPatternHelper (Handlebars) {
+  Handlebars.registerHelper('pattern', (id, rootContext, opts) => {
+    // Retrieve pattern object from ID
+    const patternObj = utils.deepPattern(id, rootContext.patterns);
+    if (!patternObj) { // TODO yeah: what then?
+      return 'nope';
+    }
+    // Build a local context TODO Move this
+    const localContext = Object.assign({},
+      rootContext, patternObj, patternObj.data);
+
+    // Find and work with partial template
+    let template = Handlebars.partials[id];
+    if (template) {
+      if (typeof template !== 'function') {
+        template = Handlebars.compile(template);
+      }
+      // Render and return
+      return template(localContext);
+    }
+  });
+  return Handlebars;
+}
+
+export default registerPatternHelper;

--- a/src/parse/collections.js
+++ b/src/parse/collections.js
@@ -1,0 +1,34 @@
+import * as utils from '../utils';
+import Promise from 'bluebird';
+
+function walkCollections (patternData, options, filePromises = []) {
+  for (const patternKey in patternData) {
+    if (patternKey === 'collection') {
+      // TODO Should this be some sort of option?
+      const glob = patternData.collection.path + '/collection.+(yaml|yml|json)';
+      filePromises.push(utils.readFiles(glob, options).then(metadata => {
+        if (metadata && metadata.length) {
+          // Extend collection data with data from file (first match)
+          patternData.collection = Object.assign(patternData.collection,
+            metadata[0].contents);
+        }
+      }));
+    } else {
+      return walkCollections(patternData[patternKey], options, filePromises);
+    }
+  }
+  return filePromises;
+}
+
+/**
+ * Extend the `collection` objects in `drizzleData.patterns` with (optional)
+ * metadata from `collection` files.
+ */
+function parseCollections (patternData, options) {
+  return Promise.all(walkCollections(patternData, options))
+    .then(() => {
+      return patternData;
+    });
+}
+
+export default parseCollections;

--- a/src/parse/patterns.js
+++ b/src/parse/patterns.js
@@ -1,4 +1,5 @@
 import * as utils from '../utils';
+import path from 'path';
 
 /**
  * Parse collection information for the pattern in `patternFile`. Resolve
@@ -16,7 +17,8 @@ function initCollection (patternFile, patternData, relativeRoot, options) {
 
   collectionEntry.collection = collectionEntry.collection || {
     items: {},
-    name: utils.titleCase(collectionKey) // TODO Allow override
+    name: utils.titleCase(collectionKey), // TODO Allow override
+    path: path.dirname(patternFile.path)
   };
   return collectionEntry.collection.items;
 }

--- a/src/parse/patterns.js
+++ b/src/parse/patterns.js
@@ -1,6 +1,18 @@
 import * as utils from '../utils';
 
 /**
+ * `name` is a specially-recognized key in the pattern
+ * that can override naming by filename
+ *
+ * @param {Object} patternFile
+ * @return {String}
+ */
+function patternName (patternFile) {
+  return ((patternFile.data && patternFile.data.name) ||
+    utils.titleCase(utils.keyname(patternFile.path)));
+}
+
+/**
  *
  */
 function parsePatterns (options) {
@@ -28,7 +40,6 @@ function parsePatterns (options) {
         name: utils.titleCase(collectionKey) // TODO Allow override
       };
 
-      // TODO This is the place to assert ordering
       // Each pattern is added to the `items` object of its parent collection
       collectionEntry
         .collection
@@ -36,7 +47,7 @@ function parsePatterns (options) {
           patternFile,
           {
             id: utils.resourceId(patternFile, relativeRoot, 'patterns'),
-            name: utils.titleCase(utils.keyname(patternFile.path))
+            name: patternName(patternFile)
           }
         );
     });

--- a/src/parse/patterns.js
+++ b/src/parse/patterns.js
@@ -1,6 +1,27 @@
 import * as utils from '../utils';
 
 /**
+ * Parse collection information for the pattern in `patternFile`. Resolve
+ * to the `items` object in the owning collection so that the pattern data
+ * may be inserted there.
+ */
+function initCollection (patternFile, patternData, relativeRoot, options) {
+  const pathBits = utils.relativePathArray(
+    patternFile.path,
+    relativeRoot);
+
+  const collectionEntry = utils.deepObj(pathBits, patternData);
+  const collectionKey = (pathBits.length && pathBits.length > 0) ?
+    pathBits[pathBits.length - 1] : 'patterns';
+
+  collectionEntry.collection = collectionEntry.collection || {
+    items: {},
+    name: utils.titleCase(collectionKey) // TODO Allow override
+  };
+  return collectionEntry.collection.items;
+}
+
+/**
  * `name` is a specially-recognized key in the pattern
  * that can override naming by filename
  *
@@ -13,43 +34,27 @@ function patternName (patternFile) {
 }
 
 /**
- *
+ * Parse all patterns file. For each pattern, make sure its collection
+ * is initialized (parsed) and add pattern data to the collection's items
+ * object.
  */
 function parsePatterns (options) {
   const patternData = {};
+  // First, read pattern files...
   return utils.readFiles(options.src.patterns, options).then(fileData => {
     const relativeRoot = utils.commonRoot(fileData);
+
     fileData.forEach(patternFile => {
-      const pathBits = utils.relativePathArray(
-        patternFile.path,
-        relativeRoot);
+      const collectionItemEntry = initCollection(
+        patternFile, patternData, relativeRoot, options);
 
-      // TODO `patterns` name should be an option, not hard-coded
-      // TODO All this collection munging should be broken out
-      const collectionKey = (pathBits.length && pathBits.length > 0) ?
-        pathBits[pathBits.length - 1] : 'patterns';
-      // Retrieve the correct object reference where we should put this
-      // pattern. This represents the "collection" containing this pattern.
-      const collectionEntry = utils.deepObj(pathBits, patternData);
-
-      // The entry returned represents the collection to which patternFile
-      // belongs. Make sure the collection metadata is present.
-      // TODO: This is the place to look for collection overrides, maybe?
-      collectionEntry.collection = collectionEntry.collection || {
-        items: {},
-        name: utils.titleCase(collectionKey) // TODO Allow override
-      };
-
-      // Each pattern is added to the `items` object of its parent collection
-      collectionEntry
-        .collection
-        .items[utils.resourceKey(patternFile)] = Object.assign(
-          patternFile,
-          {
-            id: utils.resourceId(patternFile, relativeRoot, 'patterns'),
-            name: patternName(patternFile)
-          }
-        );
+      collectionItemEntry[utils.resourceKey(patternFile)] = Object.assign(
+        patternFile,
+        {
+          id: utils.resourceId(patternFile, relativeRoot, 'patterns'),
+          name: patternName(patternFile)
+        }
+      );
     });
     return patternData;
   });

--- a/src/parse/patterns.js
+++ b/src/parse/patterns.js
@@ -1,5 +1,6 @@
 import * as utils from '../utils';
 import path from 'path';
+import parseCollections from './collections';
 
 /**
  * Parse collection information for the pattern in `patternFile`. Resolve
@@ -59,6 +60,8 @@ function parsePatterns (options) {
       );
     });
     return patternData;
+  }).then(patternData => {
+    return parseCollections(patternData, options);
   });
 }
 

--- a/src/prepare/helpers.js
+++ b/src/prepare/helpers.js
@@ -1,4 +1,5 @@
 import * as utils from '../utils';
+import registerPatternHelper from '../helpers/pattern';
 
 /**
  * Register helpers on Handlebars. Helpers (helperOpts) can be provided as
@@ -44,7 +45,8 @@ function prepareHelpers (Handlebars, helperOpts = {}) {
       for (var helper in helpers) {
         Handlebars.registerHelper(helper, helpers[helper]);
       }
-      return Handlebars.helpers;
+      registerPatternHelper(Handlebars);
+
     });
 }
 

--- a/src/prepare/patterns.js
+++ b/src/prepare/patterns.js
@@ -1,4 +1,6 @@
 import * as utils from '../utils';
+import frontMatter from 'front-matter';
+
 /**
  * Register a glob of partials.
  * @param {Object} Handlebars instance
@@ -10,7 +12,8 @@ function preparePatterns (Handlebars, patterns = '') {
     patternFiles.forEach(patternFile => {
       const partialKey = utils.resourceId(
         patternFile, relativeRoot, 'patterns');
-      Handlebars.registerPartial(partialKey, patternFile.contents);
+      const patternContents = frontMatter(patternFile.contents).body;
+      Handlebars.registerPartial(partialKey, patternContents);
     });
     return Handlebars.partials;
   });

--- a/src/render/collections.js
+++ b/src/render/collections.js
@@ -1,5 +1,5 @@
+import collectionContext from './context/collection';
 import * as renderUtils from './utils';
-import * as utils from '../utils';
 
 /**
  * For any given `patterns` entry, render a pattern-collection page for
@@ -15,7 +15,7 @@ import * as utils from '../utils';
 function renderCollection (patterns, drizzleData, collectionKey) {
   patterns.collection.contents = renderUtils.applyTemplate(
     drizzleData.layouts.patternCollection.contents, // TODO obviously fragile
-    renderUtils.localContext(patterns.collection, drizzleData),
+    collectionContext(patterns.collection, drizzleData),
     drizzleData.options);
   return patterns;
 }

--- a/src/render/collections.js
+++ b/src/render/collections.js
@@ -12,7 +12,7 @@ import * as utils from '../utils';
  * @param {String} collectionKey The key of the current set of `patterns`.
  *                               Used to derive the collection's "name"
  */
-function renderPatternCollection (patterns, drizzleData, collectionKey) {
+function renderCollection (patterns, drizzleData, collectionKey) {
   patterns.collection.contents = renderUtils.applyTemplate(
     drizzleData.layouts.patternCollection.contents, // TODO obviously fragile
     renderUtils.localContext(patterns.collection, drizzleData),
@@ -30,19 +30,19 @@ function renderPatternCollection (patterns, drizzleData, collectionKey) {
  * @param {String} currentKey   The key for the current `patterns` object.
  * @return {Object} drizzleData All drizzleData
  */
-function walkPatterns (patterns, drizzleData, currentKey = 'patterns') {
+function walkCollections (patterns, drizzleData, currentKey = 'patterns') {
   for (const patternKey in patterns) {
     if (patternKey === 'collection') {
-      renderPatternCollection(patterns, drizzleData, currentKey);
+      renderCollection(patterns, drizzleData, currentKey);
     } else {
-      walkPatterns(patterns[patternKey], drizzleData, patternKey);
+      walkCollections(patterns[patternKey], drizzleData, patternKey);
     }
   }
   return drizzleData.patterns;
 }
 
-function renderPatterns (drizzleData) {
-  return walkPatterns(drizzleData.patterns, drizzleData);
+function renderCollections (drizzleData) {
+  return walkCollections(drizzleData.patterns, drizzleData);
 }
 
-export default renderPatterns;
+export default renderCollections;

--- a/src/render/context/collection.js
+++ b/src/render/context/collection.js
@@ -1,0 +1,7 @@
+function collectionContext (collection, drizzleData) {
+  const context = Object.assign({}, collection);
+  context.drizzle = drizzleData;
+  return context;
+}
+
+export default collectionContext;

--- a/src/render/context/page.js
+++ b/src/render/context/page.js
@@ -1,0 +1,7 @@
+function pageContext (page, drizzleData) {
+  const context = Object.assign({}, page);
+  context.drizzle = drizzleData;
+  return context;
+}
+
+export default pageContext;

--- a/src/render/context/pattern.js
+++ b/src/render/context/pattern.js
@@ -1,5 +1,10 @@
 import * as utils from '../../utils';
 
+/**
+ * Generate a local context for a pattern before it is rendered
+ * Merge in data from its collection and bring its `data` properties
+ * up to top level.
+ */
 function patternContext (pattern, drizzleData) {
   const context = Object.assign({}, pattern);
   context.drizzle = drizzleData;

--- a/src/render/context/pattern.js
+++ b/src/render/context/pattern.js
@@ -1,0 +1,16 @@
+import * as utils from '../../utils';
+
+function patternContext (pattern, drizzleData) {
+  const context = Object.assign({}, pattern);
+  context.drizzle = drizzleData;
+  if (typeof pattern.data === 'object') {
+    for (const dataKey in pattern.data) {
+      context[dataKey] = pattern.data[dataKey];
+    }
+    delete context.data;
+  }
+  context.collection = utils.deepCollection(pattern.id, drizzleData.patterns);
+  return context;
+}
+
+export default patternContext;

--- a/src/render/index.js
+++ b/src/render/index.js
@@ -1,10 +1,10 @@
 import renderPages from './pages';
-import renderPatterns from './patterns';
+import renderCollections from './collections';
 
 function render (drizzleData) {
   return Promise.all([
     renderPages(drizzleData),
-    renderPatterns(drizzleData)
+    renderCollections(drizzleData)
   ]).then(allData => {
     return {
       data    : drizzleData.data,

--- a/src/render/pages.js
+++ b/src/render/pages.js
@@ -1,4 +1,5 @@
 import * as renderUtils from './utils';
+import pageContext from './context/page';
 
 /**
  * Wrap the page's current contents with an `extend` helper
@@ -34,7 +35,7 @@ function wrapWithLayout (page, drizzleData) {
 function renderPage (page, drizzleData) {
   page.contents = renderUtils.applyTemplate(
     wrapWithLayout(page, drizzleData),
-    renderUtils.localContext(page, drizzleData),
+    pageContext(page, drizzleData),
     drizzleData.options);
   return page.contents;
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -105,6 +105,14 @@ function deepPattern (patternId, obj) {
   return deepObj(pathBits, obj, false);
 }
 
+function deepCollection (patternId, obj) {
+  const pathBits = patternId.split('.'); // TODO pattern separator elsewhere?
+  pathBits.pop();
+  pathBits.push('collection');
+  pathBits.shift();
+  return deepObj(pathBits, obj, false);
+}
+
 /**
  * Take a given glob and convert it to a glob that will match directories
  * (instead of files). Return Promise that resolves to matching dirs.
@@ -312,6 +320,7 @@ function titleCase (str) {
 }
 
 export { commonRoot,
+         deepCollection,
          deepObj,
          deepPattern,
          dirname,

--- a/test/config.js
+++ b/test/config.js
@@ -75,7 +75,7 @@ var config = {
       layouts : fixturePath('layouts/**/*'),
       pages   : fixturePath('pages/**/*'),
       partials: fixturePath('partials/**/*.hbs'),
-      patterns: fixturePath('patterns/**/*')
+      patterns: fixturePath('patterns/**/*.html')
     },
     dest: './test/dist',
     helpers: fixturePath('helpers/**/*.js'),

--- a/test/fixtures/layouts/patternCollection.html
+++ b/test/fixtures/layouts/patternCollection.html
@@ -2,7 +2,7 @@
   {{#content "body"}}
     <h2>{{name}}</h2>
     {{#each items}}
-      {{@key}}
+      {{#pattern id @root}}{{/pattern}}
     {{/each}}
   {{/content}}
 {{/extend}}

--- a/test/fixtures/pages/components.html
+++ b/test/fixtures/pages/components.html
@@ -11,5 +11,7 @@ layout: page
     {{#each patterns.components.button.items}}
       <div class="pattern">foo</pattern>
     {{/each}}
+
+    {{#pattern patterns.components.button.collection.items.aardvark.id @root }}{{/pattern}}
   {{/content}}
 {{/extend}}

--- a/test/fixtures/pages/components.html
+++ b/test/fixtures/pages/components.html
@@ -8,10 +8,10 @@ layout: page
   {{#content 'body'}}
     <h1>{{title}}</h1>
 
-    {{#each patterns.components.button.items}}
+    {{#each drizzle.patterns.components.button.items}}
       <div class="pattern">foo</pattern>
     {{/each}}
 
-    {{#pattern patterns.components.button.collection.items.aardvark.id @root }}{{/pattern}}
+    {{#pattern drizzle.patterns.components.button.collection.items.aardvark.id @root }}{{/pattern}}
   {{/content}}
 {{/extend}}

--- a/test/fixtures/patterns/components/button/aardvark.html
+++ b/test/fixtures/patterns/components/button/aardvark.html
@@ -1,5 +1,6 @@
 ---
 notes: |
   foo `bar`
+action: 'ding'
 ---
-<a href="#" class="button">{{home.action}} Me, {{name}}</a>
+<a href="#" class="button">{{action}} Me, {{name}}</a>

--- a/test/fixtures/patterns/components/button/aardvark.html
+++ b/test/fixtures/patterns/components/button/aardvark.html
@@ -5,3 +5,4 @@ notes: |
 action: 'ding'
 ---
 <a href="#" class="button">{{action}} Me, {{name}}</a>
+<h4>{{collection.name}}</h4>

--- a/test/fixtures/patterns/components/button/aardvark.html
+++ b/test/fixtures/patterns/components/button/aardvark.html
@@ -1,4 +1,5 @@
 ---
+name: Something Else
 notes: |
   foo `bar`
 action: 'ding'

--- a/test/fixtures/patterns/components/button/base.html
+++ b/test/fixtures/patterns/components/button/base.html
@@ -11,7 +11,5 @@ links:
 ---
 
 <button class="pattern-button {{class}}" type="button"{{#if disabled}} disabled{{/if}}>
-  {{#block "content"}}
-    Default Button
-  {{/block}}
+
 </button>

--- a/test/fixtures/patterns/components/button/collection.yml
+++ b/test/fixtures/patterns/components/button/collection.yml
@@ -1,1 +1,6 @@
 name: Not a Button
+order:
+  - base
+  - aardvark
+  - disabled
+  - 'color-variation'

--- a/test/fixtures/patterns/components/button/collection.yml
+++ b/test/fixtures/patterns/components/button/collection.yml
@@ -1,0 +1,1 @@
+name: Not a Button

--- a/test/fixtures/patterns/components/button/color-variation.html
+++ b/test/fixtures/patterns/components/button/color-variation.html
@@ -7,26 +7,4 @@ notes: |
   + `pattern-button--other`: Modifier to apply "Other" color
 ---
 
-{{#embed "button.base"}}
-  {{#content "content"}}
-    Primary
-  {{/content}}
-{{/embed}}
-
-{{#embed "button.base" class="pattern-button--secondary"}}
-  {{#content "content"}}
-    Secondary
-  {{/content}}
-{{/embed}}
-
-{{#embed "button.base" class="pattern-button--tertiary"}}
-  {{#content "content"}}
-    Tertiary
-  {{/content}}
-{{/embed}}
-
-{{#embed "button.base" class="pattern-button--other"}}
-  {{#content "content"}}
-    Other
-  {{/content}}
-{{/embed}}
+Oh my!

--- a/test/fixtures/patterns/components/button/disabled.html
+++ b/test/fixtures/patterns/components/button/disabled.html
@@ -4,26 +4,4 @@ notes: |
   semi-transparent appearance.
 ---
 
-{{#embed "button.base" disabled="true"}}
-  {{#content "content"}}
-    Primary
-  {{/content}}
-{{/embed}}
-
-{{#embed "button.base" class="pattern-button--secondary" disabled="true"}}
-  {{#content "content"}}
-    Secondary
-  {{/content}}
-{{/embed}}
-
-{{#embed "button.base" class="pattern-button--tertiary" disabled="true"}}
-  {{#content "content"}}
-    Tertiary
-  {{/content}}
-{{/embed}}
-
-{{#embed "button.base" class="pattern-button--other" disabled="true"}}
-  {{#content "content"}}
-    Other
-  {{/content}}
-{{/embed}}
+Oh ding!

--- a/test/parse/patterns.js
+++ b/test/parse/patterns.js
@@ -67,4 +67,12 @@ describe ('parse/patterns', () => {
       //config.logObj(patternData.components.button.collection);
     });
   });
+  describe ('parse/collections', () => {
+    it ('should extend pattern collections with file metadata', () => {
+      return parsePatterns(opts).then(patternData => {
+        expect(patternData.components.button.collection.name).to
+          .equal('Not a Button');
+      });
+    });
+  });
 });

--- a/test/parse/patterns.js
+++ b/test/parse/patterns.js
@@ -70,8 +70,10 @@ describe ('parse/patterns', () => {
   describe ('parse/collections', () => {
     it ('should extend pattern collections with file metadata', () => {
       return parsePatterns(opts).then(patternData => {
-        expect(patternData.components.button.collection.name).to
+        var collection = patternData.components.button.collection;
+        expect(collection.name).to
           .equal('Not a Button');
+        expect(collection.order).to.be.an('Array');
       });
     });
   });

--- a/test/parse/patterns.js
+++ b/test/parse/patterns.js
@@ -16,6 +16,11 @@ describe ('parse/patterns', () => {
       expect(patternData.collection.items).to.have.keys('pink');
     });
   });
+  describe('it should add basic collection data to patterns', () => {
+    return parsePatterns(opts).then(patternData => {
+      expect(patternData.collection).to.contain.keys('name', 'path', 'items');
+    });
+  });
   describe('it should allow override of `name` prop', () => {
     return parsePatterns(opts).then(patternData => {
       expect(patternData.components.button.collection.items.aardvark)

--- a/test/parse/patterns.js
+++ b/test/parse/patterns.js
@@ -7,12 +7,21 @@ var utils = require('../../dist/utils');
 
 describe ('parse/patterns', () => {
   var opts = config.parseOptions(config.fixtureOpts);
+
   it ('should correctly build data object from patterns', () => {
     return parsePatterns(opts).then(patternData => {
       expect(patternData).to.be.an('object');
       expect(patternData).to.have.keys(
         'collection', 'fingers', 'components', 'typography');
       expect(patternData.collection.items).to.have.keys('pink');
+    });
+  });
+  describe('it should allow override of `name` prop', () => {
+    return parsePatterns(opts).then(patternData => {
+      expect(patternData.components.button.collection.items.aardvark)
+        .to.contain.key('name');
+      expect(patternData.components.button.collection.items.aardvark.name)
+        .to.equal('Something Else');
     });
   });
   describe ('pattern object structure', () => {

--- a/test/prepare/index.js
+++ b/test/prepare/index.js
@@ -40,4 +40,9 @@ describe ('prepare/index', () => {
       );
     });
   });
+  it ('should register the `pattern` helper', () => {
+    return prepare(opts).then(preparedOpts => {
+      expect(preparedOpts.handlebars.helpers).to.contain.key('pattern');
+    });
+  });
 });

--- a/test/render/collections.js
+++ b/test/render/collections.js
@@ -4,9 +4,9 @@ var config = require('../config');
 var expect = chai.expect;
 var prepare = require('../../dist/prepare/');
 var parse = require('../../dist/parse/');
-var renderPatterns = require('../../dist/render/patterns');
+var renderPatterns = require('../../dist/render/collections');
 
-describe ('render/patterns', () => {
+describe ('render/collections', () => {
   var opts, allData;
   before (() => {
     opts = config.parseOptions(config.fixtureOpts);

--- a/test/render/context/pattern.js
+++ b/test/render/context/pattern.js
@@ -1,0 +1,41 @@
+/* global describe, it, before */
+var chai = require('chai');
+var config = require('../../config');
+var expect = chai.expect;
+var parse = require('../../../dist/parse/');
+var patternContext = require('../../../dist/render/context/pattern');
+
+describe ('render/context/patterns', () => {
+  var parsed, opts;
+  before (() => {
+    opts = config.parseOptions(config.fixtureOpts);
+    parsed = parse(opts);
+    return parsed;
+  });
+  it ('should add collection data to the context', () => {
+    return parsed.then(allData => {
+      var context = patternContext(
+        allData.patterns.components.collection.items.orange, allData);
+      expect(context).to.contain.key('collection');
+      expect(context.collection).to.be.an('object').and.to.contain.keys(
+        'items', 'name');
+    });
+  });
+  it ('should put data properties at top level', () => {
+    return parsed.then(allData => {
+      var context = patternContext(
+        allData.patterns.fingers.collection.items.pamp, allData);
+      expect(context).not.to.contain.key('data');
+      expect(context).to.contain.keys('notes', 'links');
+    });
+  });
+  it ('should add all drizzle data', () => {
+    return parsed.then(allData => {
+      var context = patternContext(
+        allData.patterns.fingers.collection.items.pamp, allData);
+      expect(context).to.contain.keys('drizzle');
+      expect(context.drizzle).to.contain.keys('pages', 'patterns', 'data');
+    });
+  });
+
+});


### PR DESCRIPTION
This is a pretty chunky PR that establishes the foundation of being able to embed patterns with the correct context, via the `pattern` helper as well as other context tools. It also introduces some rudimentary `collection` metadata control, which I'll expand upon. It also more concretely uses the notion of collections overall, as they are more pervasive than our starting point suggested. Still, this is not particularly interesting code, functional, so I'm not looking for a terribly deep assessment :). 

I have started throwing in tests, but commenting and clarity could definitely use some attention!

/cc @erikjung 