### PR TITLE
Field parsing

### DIFF
--- a/src/defaults.js
+++ b/src/defaults.js
@@ -12,9 +12,11 @@ const defaults = {
     pages   : '',
     patterns: 'patterns/'
   },
+  fieldParsers  : {
+    'notes'     : 'markdown'
+  },
   handlebars    : Handlebars,
   helpers       : {},
-  markdownFields: ['notes'],
   parsers       : parsers,
   src: {
     data    : ['src/data/**/*'],

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -12,9 +12,7 @@ const defaults = {
     pages   : '',
     patterns: 'patterns/'
   },
-  fieldParsers  : {
-    'notes'     : 'markdown'
-  },
+  fieldParsers  : { },
   handlebars    : Handlebars,
   helpers       : {},
   parsers       : parsers,

--- a/src/parse/patterns/pattern.js
+++ b/src/parse/patterns/pattern.js
@@ -37,15 +37,13 @@ function patternName (patternFile) {
  * with a few things.
  */
 function parsePattern (patternFile, patternData, relativeRoot, options) {
-  let parsedPattern = Object.assign(
+  return parseDataFields(Object.assign(
     patternFile,
     {
       id: resourceId(patternFile, relativeRoot, 'patterns'),
       name: patternName(patternFile)
     }
-  );
-  parsedPattern = parseDataFields(parsedPattern, options);
-  return parsedPattern;
+  ), options);
 }
 
 export default parsePattern;

--- a/src/parse/patterns/pattern.js
+++ b/src/parse/patterns/pattern.js
@@ -1,5 +1,6 @@
 import { resourceId } from '../../utils/object';
 import { keyname, titleCase } from '../../utils/shared';
+import { parseField } from '../../utils/parse';
 
 /**
  * If any of the pattern's data fields are objects containing a 'parser'
@@ -13,19 +14,8 @@ import { keyname, titleCase } from '../../utils/shared';
 function parseDataFields (pattern, options) {
   pattern.data = pattern.data || {};
   for (const dataKey in pattern.data) {
-    const field = pattern.data[dataKey];
-    if (typeof field === 'object' &&
-      field.hasOwnProperty('parser')) {
-      if (!options.parsers.hasOwnProperty(field.parser)) {
-        // TODO Here's a hook for error handling
-      } else if (!field.hasOwnProperty('contents')) {
-        // TODO again
-      } else {
-        // Replace the data field with the contents run through the parser.
-        pattern.data[dataKey] = options.parsers[field.parser]
-          .parseFn(field.contents).contents;
-      }
-    }
+    const parsedField = parseField(dataKey, pattern.data[dataKey], options);
+    pattern.data[dataKey] = parsedField.contents;
   }
   return pattern;
 }

--- a/src/parse/patterns/pattern.js
+++ b/src/parse/patterns/pattern.js
@@ -2,6 +2,35 @@ import { resourceId } from '../../utils/object';
 import { keyname, titleCase } from '../../utils/shared';
 
 /**
+ * If any of the pattern's data fields are objects containing a 'parser'
+ * key, run the string in `contents` through the indicated parser function and
+ * set the value of the field to the resulting string. Mutates pattern.data.
+ *
+ * @param {Object} pattern    pattern object
+ * @param {Object} options
+ * @return {Object} Updated pattern
+ */
+function parseDataFields (pattern, options) {
+  pattern.data = pattern.data || {};
+  for (const dataKey in pattern.data) {
+    const field = pattern.data[dataKey];
+    if (typeof field === 'object' &&
+      field.hasOwnProperty('parser')) {
+      if (!options.parsers.hasOwnProperty(field.parser)) {
+        // TODO Here's a hook for error handling
+      } else if (!field.hasOwnProperty('contents')) {
+        // TODO again
+      } else {
+        // Replace the data field with the contents run through the parser.
+        pattern.data[dataKey] = options.parsers[field.parser]
+          .parseFn(field.contents).contents;
+      }
+    }
+  }
+  return pattern;
+}
+
+/**
  * `name` is a specially-recognized key in the pattern
  * that can override naming by filename
  *
@@ -17,14 +46,16 @@ function patternName (patternFile) {
  * Generate a pattern entry (object) by extending the patternFile
  * with a few things.
  */
-function parsePattern (patternFile, patternData, relativeRoot) {
-  return Object.assign(
+function parsePattern (patternFile, patternData, relativeRoot, options) {
+  let parsedPattern = Object.assign(
     patternFile,
     {
       id: resourceId(patternFile, relativeRoot, 'patterns'),
       name: patternName(patternFile)
     }
   );
+  parsedPattern = parseDataFields(parsedPattern, options);
+  return parsedPattern;
 }
 
 export default parsePattern;

--- a/src/parse/patterns/patterns.js
+++ b/src/parse/patterns/patterns.js
@@ -24,7 +24,7 @@ function parsePatterns (options) {
         path: path.dirname(patternFile.path)
       };
       parentObj.collection.items[patternKey] = parsePattern(
-        patternFile, patternData, relativeRoot);
+        patternFile, patternData, relativeRoot, options);
     });
     return patternData;
   });

--- a/src/utils/parse.js
+++ b/src/utils/parse.js
@@ -59,6 +59,38 @@ function matchParser (filepath, parsers = {}) {
 }
 
 /**
+ * Evaluate a single field of data and see if it should be run through a parser.
+ * @param {String} fieldKey
+ * @param {Object|String} fieldData
+ * @param {Object} options
+ * @return {Object} parsed data; contains `contents` property.
+ * @see parse/parsers
+ */
+function parseField (fieldKey, fieldData, options) {
+  let parseFn = contents => ({ contents: contents });
+  let contents = fieldData;
+  // Check to see if options.fieldParsers contains this key
+  if (options.fieldParsers.hasOwnProperty(fieldKey)) {
+    const parserKey = options.fieldParsers[fieldKey];
+    parseFn = options.parsers[parserKey].parseFn;
+    contents = (typeof fieldData === 'string') ? fieldData : fieldData.contents;
+  }
+  // Check to see if there is a manually-added parser in the data
+  if (typeof fieldData === 'object' && fieldData.hasOwnProperty('parser')) {
+    if (options.parsers.hasOwnProperty(fieldData.parser)) {
+      parseFn = options.parsers[fieldData.parser].parseFn;
+    }
+    else { // TODO Handle error
+    }
+    contents = fieldData.contents;
+    if (!fieldData.hasOwnProperty('contents')) {
+      // TODO again
+    }
+  }
+  return parseFn(contents);
+}
+
+/**
  * Given an object representing a page or pattern or other file:
  * If that object has a `data` property, use that to
  * create the right kind of context for the object. Process relevant fields
@@ -144,6 +176,7 @@ function readFilesKeyed (glob, options = {}) {
 export { getFiles,
          isGlob,
          matchParser,
+         parseField,
          parseLocalData,
          readFiles,
          readFilesKeyed

--- a/test/fixtures/patterns/fingers/ideal.html
+++ b/test/fixtures/patterns/fingers/ideal.html
@@ -1,4 +1,12 @@
 ---
 name: Idealist
+ancillary:
+  parser: markdown
+  contents: |
+    This is a longer-form thing I'd like to have parsed with markdown.
+    * foo
+    * bar
+    * baz
+
 ---
 I am ideal.

--- a/test/options.js
+++ b/test/options.js
@@ -9,9 +9,9 @@ describe ('options', () => {
     'beautifier',
     'dest',
     'destPaths',
+    'fieldParsers',
     'handlebars',
     'helpers',
-    'markdownFields',
     'parsers',
     'src'
   ];

--- a/test/parse/patterns/patterns.js
+++ b/test/parse/patterns/patterns.js
@@ -29,6 +29,17 @@ describe ('parse/patterns', () => {
         .to.equal('Something Else');
     });
   });
+  describe ('data field parsing', () => {
+    it ('should run data fields through parsers', () => {
+      return parsePatterns(opts).then(patternData => {
+        var ideal = patternData.fingers.collection.items.ideal;
+        expect(ideal).to.contain.keys('data');
+        expect(ideal.data).to.contain.keys('ancillary');
+        expect(ideal.data.ancillary).to.be.a('string');
+        expect(ideal.data.ancillary).to.contain('<ul>');
+      });
+    });
+  });
   describe ('pattern object structure', () => {
     it ('should define the appropriate properties for each pattern', () => {
       return parsePatterns(opts).then(patternData => {

--- a/test/utils/parse.js
+++ b/test/utils/parse.js
@@ -66,7 +66,9 @@ describe ('utils/parse', () => {
     });
   });
   describe('parseField', () => {
-    var opts = config.parseOptions(config.fixtureOpts);
+    var opts = config.parseOptions({ fieldParsers: {
+      'notes': 'markdown'
+    }});
     it ('should run fields through fieldParsers from options', () => {
       // `notes` defaults to markdown parsing (see default opts)
       var parsedField = utils.parseField(

--- a/test/utils/parse.js
+++ b/test/utils/parse.js
@@ -65,6 +65,28 @@ describe ('utils/parse', () => {
       expect(parser('ding')).to.equal('foo');
     });
   });
+  describe('parseField', () => {
+    var opts = config.parseOptions(config.fixtureOpts);
+    it ('should run fields through fieldParsers from options', () => {
+      // `notes` defaults to markdown parsing (see default opts)
+      var parsedField = utils.parseField(
+        'notes', 'these are some notes', opts);
+      expect(parsedField).to.be.an('object');
+      expect(parsedField).to.contain.keys('contents', 'data');
+      expect(parsedField.contents).to.be.a('string').and.to.contain('<p>');
+    });
+    it ('should heed `parser` property in passed object', () => {
+      var fieldData = {
+        parser: 'markdown',
+        contents: 'A nobler thing tis'
+      };
+      var parsedField = utils.parseField(
+        'ding', fieldData, opts);
+      expect(parsedField).to.be.an('object');
+      expect(parsedField).to.contain.keys('contents', 'data');
+      expect(parsedField.contents).to.be.a('string').and.to.contain('<p>');
+    });
+  });
   describe('readFiles', () => {
     var parsers = {
       default: {


### PR DESCRIPTION
This PR introduces the ability to "parse" front matter fields in patterns, and there are two ways to do it, which I hope will generally please folks. I can also expand this feature to `pages` (it probably should be done for consistency's sake).

This feature was created to address #3 but is more generic and extensible should there be other desires to process field contents beyond `markdown`.

## Field-Specific Parsing, Variant One

The builder function takes a `fieldParsers` option, which is an object mapping field names to "parser keys". Default parsers are [in src/parse/parsers.js](https://github.com/cloudfour/drizzle-builder/blob/feature-field-parsing/src/parse/parsers.js) and can also be extended with options (`parsers` option). But, anyway, default parsers include `markdown`, `yaml`, etc. Let's concentrate on `markdown` for the moment.

The default value for `options.fieldParsers` is:

```
{
  'notes': 'markdown'
}
```

This means any time front matter is encountered in patterns keyed by `notes`, it will run it through the parser keyed by `markdown`.

This is a useful way to set up fields for a project when you know that specific fields should always be run through markdown. If it's terrifically annoying as-is, i can make the default object empty (meaning no fields will "automatically" be markdown-i-fied out of the gate).

This global method was my first attempt at solving the parse-with-markdown issue, and it was pointed out at the time that it didn't fully solve the problem, so, without further ado:

## Field-Specific Parsing, Variant Two

The second way to cause front-matter in patterns to be parsed in a specific way is to do it inside of a pattern. e.g.:

```yaml
---
foo: bar
discourse:
  parser: markdown
  contents: |
    These are some long contents I want to run through markdown.
    * foo
    * bar
    * baz
---
```

Any parser on a field inside of a pattern will supersede a global setting (if there is a conflict). 

I considered various other syntaxes for this, concerned that there would be some displeasure at having both a `parser` and `contents` property on these fields. But after looking at other options, none felt as technically clean—they involved fragile-feeling regexps and having sullied source data (i.e. information about parsing munged in with the value of the field, which felt wrong).

One of my plans tomorrow is to introduce some helpful error handling that could point out to dev/signers if a field is mis-structured (e.g. missing a `contents` property) so that this won't be so mysterious. Also, there's a bigger task of documentation ahead of us, of course. 

/cc @tylersticka @mrgerardorodriguez @saralohr @nicolemors 