### PR TITLE
Chore: Clean Up Write Modules

### DIFF
--- a/src/utils/write.js
+++ b/src/utils/write.js
@@ -17,4 +17,28 @@ function write (filepath, contents) {
   });
 }
 
-export { write };
+/**
+ * Write a single resource (e.g. page or pattern-collection) to
+ * the filesystem. Update the resourceObj with the outputPath.
+ *
+ * @param {Array} entryKeys   path elements leading to resource
+ * @param {Object} resourceObj
+ * @param {String} destPath   path prefix for dest output.
+ *                            @see defaults.dest
+ * @return {Promise}
+ */
+function writeResource (entryKeys, resourceObj, destPath) {
+  const filename = entryKeys.pop();
+  const outputPath = path.join(
+    entryKeys.join(path.sep),
+    `${filename}.html`
+  );
+  const fullPath = path.normalize(path.join(
+    destPath,
+    outputPath
+  ));
+  resourceObj.outputPath = fullPath;
+  return write(fullPath, resourceObj.contents);
+}
+
+export { write, writeResource };

--- a/src/write/collections.js
+++ b/src/write/collections.js
@@ -1,64 +1,45 @@
-import path from 'path';
-import { write } from '../utils/write';
+import { writeResource } from '../utils/write';
 
 /**
- * Figure out the output path for `page` and write it to the filesystem.
- * @TODO hard-coded `.html` OK?
- *
- * @param {Object} collection         Will be mutated
- * @param {Object} drizzleData
- * @param {Array} entryKeys           path components
- * @return {Promise} for file write
- */
-function writeCollection (patterns, drizzleData, entryKeys) {
-  const collectionName = entryKeys.pop() || 'patterns'; // TODO: Hay
-  const outputPath = path.join(entryKeys.join(path.sep),
-    `${collectionName}.html`);
-  const fullPath = path.normalize(path.join(
-    drizzleData.options.dest.patterns,
-    outputPath));
-  patterns.collection.outputPath = fullPath;
-  return write(fullPath, patterns.collection.contents);
-}
-
-/**
- * Traverse pages object and write out any page objects to files. An object
- * is considered a page if it has a `contents` property.
+ * Traverse patterns object and write out any collection objects to files.
  *
  * @param {Object} pages   current level of pages tree
  * @param {Object} drizzleData
- * @param {String} currentKey  This is a bit inelegant, but we need to keep
- *                             track of the current object's key in the owning
- *                             object because it will be part of the filename(s)
+ * @param {Array} entryKeys  Array of path elements leading to this collection
  * @param {Array} writePromises All write promises so far
  * @return {Array} of Promises
  */
 function walkCollections (patterns, drizzleData,
-  currentKeys = [], writePromises = []) {
+  entryKeys = [], writePromises = []) {
   if (patterns.collection) {
     writePromises.push(
-      writeCollection(patterns, drizzleData, currentKeys));
+      writeResource(entryKeys, patterns.collection,
+        drizzleData.options.dest.patterns));
   }
   for (const patternKey in patterns) {
     // TODO Better test following
     if (patternKey !== 'items' && patternKey !== 'collection') {
-      currentKeys.push(patternKey);
+      entryKeys.push(patternKey);
       walkCollections(patterns[patternKey],
-        drizzleData, currentKeys, writePromises);
-      currentKeys.pop();
+        drizzleData, entryKeys, writePromises);
+      entryKeys.pop();
     }
   }
   return writePromises;
 }
 
 /**
- * TODO: Comment, etc.
+ * Traverse the patterns object and write out collections.
+ *
+ * @param {Object} drizzleData
+ * @return {Promise} resolving to {Object} drizzleData
  */
 function writeCollections (drizzleData) {
-  return Promise.all(walkCollections(drizzleData.patterns, drizzleData))
-    .then(writePromises => {
-      return drizzleData;
-    });
+  return Promise.all(walkCollections(
+    drizzleData.patterns,
+    drizzleData,
+    [drizzleData.options.src.patterns.basedir])
+  ).then(writePromises => drizzleData);
 }
 
 export default writeCollections;

--- a/src/write/collections.js
+++ b/src/write/collections.js
@@ -1,5 +1,8 @@
 import { writeResource } from '../utils/write';
 
+const hasCollection = patterns => patterns.hasOwnProperty('collection');
+const isCollection = patterns => patterns.hasOwnProperty('items');
+
 /**
  * Traverse patterns object and write out any collection objects to files.
  *
@@ -11,14 +14,13 @@ import { writeResource } from '../utils/write';
  */
 function walkCollections (patterns, drizzleData,
   entryKeys = [], writePromises = []) {
-  if (patterns.collection) {
+  if (hasCollection(patterns)) {
     writePromises.push(
       writeResource(entryKeys, patterns.collection,
         drizzleData.options.dest.patterns));
   }
   for (const patternKey in patterns) {
-    // TODO Better test following
-    if (patternKey !== 'items' && patternKey !== 'collection') {
+    if (!isCollection(patterns[patternKey])) {
       entryKeys.push(patternKey);
       walkCollections(patterns[patternKey],
         drizzleData, entryKeys, writePromises);

--- a/src/write/collections.js
+++ b/src/write/collections.js
@@ -3,7 +3,6 @@ import { write } from '../utils/write';
 
 /**
  * Figure out the output path for `page` and write it to the filesystem.
- * @TODO options.keys is still dumb
  * @TODO hard-coded `.html` OK?
  *
  * @param {Object} collection         Will be mutated
@@ -11,8 +10,8 @@ import { write } from '../utils/write';
  * @param {Array} entryKeys           path components
  * @return {Promise} for file write
  */
-function writePatternCollection (patterns, drizzleData, entryKeys) {
-  const collectionName = entryKeys.pop() || 'patterns';
+function writeCollection (patterns, drizzleData, entryKeys) {
+  const collectionName = entryKeys.pop() || 'patterns'; // TODO: Hay
   const outputPath = path.join(entryKeys.join(path.sep),
     `${collectionName}.html`);
   const fullPath = path.normalize(path.join(
@@ -34,17 +33,17 @@ function writePatternCollection (patterns, drizzleData, entryKeys) {
  * @param {Array} writePromises All write promises so far
  * @return {Array} of Promises
  */
-function walkPatterns (patterns, drizzleData,
+function walkCollections (patterns, drizzleData,
   currentKeys = [], writePromises = []) {
   if (patterns.collection) {
     writePromises.push(
-      writePatternCollection(patterns, drizzleData, currentKeys));
+      writeCollection(patterns, drizzleData, currentKeys));
   }
   for (const patternKey in patterns) {
     // TODO Better test following
     if (patternKey !== 'items' && patternKey !== 'collection') {
       currentKeys.push(patternKey);
-      walkPatterns(patterns[patternKey],
+      walkCollections(patterns[patternKey],
         drizzleData, currentKeys, writePromises);
       currentKeys.pop();
     }
@@ -55,11 +54,11 @@ function walkPatterns (patterns, drizzleData,
 /**
  * TODO: Comment, etc.
  */
-function writePatterns (drizzleData) {
-  return Promise.all(walkPatterns(drizzleData.patterns, drizzleData))
+function writeCollections (drizzleData) {
+  return Promise.all(walkCollections(drizzleData.patterns, drizzleData))
     .then(writePromises => {
       return drizzleData;
     });
 }
 
-export default writePatterns;
+export default writeCollections;

--- a/src/write/collections.js
+++ b/src/write/collections.js
@@ -31,7 +31,7 @@ function walkCollections (patterns, drizzleData,
 }
 
 /**
- * Traverse the patterns object and write out collections.
+ * Traverse the patterns object and write out collections HTML pages.
  *
  * @param {Object} drizzleData
  * @return {Promise} resolving to {Object} drizzleData

--- a/src/write/index.js
+++ b/src/write/index.js
@@ -1,8 +1,11 @@
 import writePages from './pages';
 import writeCollections from './collections';
 
+import DrizzleError from '../utils/error';
+
 /**
- * Write pages and collection-pages to filesystem
+ * Write pages and collection-pages to filesystem.
+ *
  * @param {Object} drizzleData All drizzle data so far
  * @return {Promise} resolving to drizzleData
  */
@@ -10,7 +13,10 @@ function write (drizzleData) {
   return Promise.all([
     writePages(drizzleData),
     writeCollections(drizzleData)
-  ]).then(() => drizzleData);
+  ]).then(
+    () => drizzleData,
+    error => new DrizzleError(error).handle(drizzleData.options.debug)
+  );
 }
 
 export default write;

--- a/src/write/pages.js
+++ b/src/write/pages.js
@@ -22,10 +22,17 @@ function walkPages (pages, drizzleData, currentKeys = [], writePromises = []) {
     currentKeys.push(pageKey);
     writePromises = writePromises.concat(
       walkPages(pages[pageKey], drizzleData, currentKeys, writePromises));
+    currentKeys.pop();
   }
   return writePromises;
 }
 
+/**
+ * Write out HTML pages for pages data.
+ *
+ * @param {Object} drizzleData
+ * @return {Promise} resolving to drizzleData
+ */
 function writePages (drizzleData) {
   return Promise.all(walkPages(drizzleData.pages, drizzleData))
     .then(() => drizzleData);

--- a/src/write/pages.js
+++ b/src/write/pages.js
@@ -1,23 +1,4 @@
-import path from 'path';
-import { write } from '../utils/write';
-
-/**
- * Figure out the output path for `page` and write it to the filesystem.
- *
- * @param {Object} page         Will be mutated
- * @param {Object} drizzleData
- * @param {String} entryKey     The keyname (filename) of the file
- * @return {Promise} for file write
- */
-function writePage (page, drizzleData, entryKeys) {
-  const fileKey = entryKeys.pop();
-  const outputPath = path.join(entryKeys.join(path.sep), fileKey + '.html');
-  const fullPath = path.normalize(path.join(
-    drizzleData.options.dest.pages,
-    outputPath));
-  page.outputPath = fullPath;
-  return write(fullPath, page.contents);
-}
+import { writeResource } from '../utils/write';
 
 /**
  * Traverse pages object and write out any page objects to files. An object
@@ -33,7 +14,7 @@ function writePage (page, drizzleData, entryKeys) {
  */
 function walkPages (pages, drizzleData, currentKeys = [], writePromises = []) {
   if (pages.contents) {
-    return writePage(pages, drizzleData, currentKeys);
+    return writeResource(currentKeys, pages, drizzleData.options.dest.pages);
   }
   for (var pageKey in pages) {
     currentKeys.push(pageKey);

--- a/src/write/pages.js
+++ b/src/write/pages.js
@@ -3,8 +3,6 @@ import { write } from '../utils/write';
 
 /**
  * Figure out the output path for `page` and write it to the filesystem.
- * @TODO options.keys is still dumb
- * @TODO hard-coded `.html` OK?
  *
  * @param {Object} page         Will be mutated
  * @param {Object} drizzleData
@@ -47,9 +45,7 @@ function walkPages (pages, drizzleData, currentKeys = [], writePromises = []) {
 
 function writePages (drizzleData) {
   return Promise.all(walkPages(drizzleData.pages, drizzleData))
-    .then(() => {
-      return drizzleData;
-    });
+    .then(() => drizzleData);
 }
 
 export default writePages;

--- a/src/write/pages.js
+++ b/src/write/pages.js
@@ -1,5 +1,7 @@
 import { writeResource } from '../utils/write';
 
+const isPage = page => page.hasOwnProperty('contents');
+
 /**
  * Traverse pages object and write out any page objects to files. An object
  * is considered a page if it has a `contents` property.
@@ -13,7 +15,7 @@ import { writeResource } from '../utils/write';
  * @return {Array} of Promises
  */
 function walkPages (pages, drizzleData, currentKeys = [], writePromises = []) {
-  if (pages.contents) {
+  if (isPage(pages)) {
     return writeResource(currentKeys, pages, drizzleData.options.dest.pages);
   }
   for (var pageKey in pages) {

--- a/test/fixtures/pages/follow-me/down/apage.md
+++ b/test/fixtures/pages/follow-me/down/apage.md
@@ -1,0 +1,8 @@
+---
+customHeader: foobar
+layout: page
+---
+
+* Thing
+* In
+* Page

--- a/test/utils/write.js
+++ b/test/utils/write.js
@@ -11,11 +11,48 @@ describe ('utils/write', () => {
   before (() => {
     return rimraf(outPath);
   });
-  it ('should create nested directories as needed', () => {
-    return utils.write(outPath + '/ding.txt', 'This is stuff').then(() => {
-      return testUtils.isFile('./test/dist/testFileWrite/ding.txt')
-      .then(result => {
-        expect(result).to.be.true;
+  describe('write/write', () => {
+    it ('should create nested directories as needed', () => {
+      return utils.write(outPath + '/ding.txt', 'This is stuff').then(() => {
+        return testUtils.isFile('./test/dist/testFileWrite/ding.txt')
+        .then(result => {
+          expect(result).to.be.true;
+        });
+      });
+    });
+  });
+  describe ('write/writeResource', () => {
+    it ('should generate an outputPath', () => {
+      var entryKeys = ['one', 'two', 'three', 'page'];
+      var pageObj = {
+        contents: 'These are some contents'
+      };
+      var dest = './test/dist/testWriteResource';
+      return utils.writeResource(entryKeys, pageObj, dest).then(updatedObj => {
+        expect(pageObj).to.contain.key('outputPath');
+      });
+    });
+    it ('should write file based on entryKeys', () => {
+      var entryKeys = ['one', 'two', 'three', 'four', 'page'];
+      var pageObj = {
+        contents: 'These are some contents'
+      };
+      var dest = './test/dist/testWriteResource';
+      return utils.writeResource(entryKeys, pageObj, dest).then(updatedObj => {
+        expect(pageObj.outputPath).to.contain('test/dist/testWriteResource');
+        expect(pageObj.outputPath).to.contain('one/two/three/four');
+      });
+    });
+    it ('should write `contents` property to file', () => {
+      var entryKeys = ['one', 'two', 'three', 'four', 'five', 'page'];
+      var pageObj = {
+        contents: 'These are some contents'
+      };
+      var dest = './test/dist/testWriteResource';
+      return utils.writeResource(entryKeys, pageObj, dest).then(updatedObj => {
+        return testUtils.fileContents(pageObj.outputPath).then(contents => {
+          expect(contents).to.equal('These are some contents');
+        });
       });
     });
   });

--- a/test/write/collections.js
+++ b/test/write/collections.js
@@ -38,7 +38,6 @@ describe ('write/collections', () => {
           'button.html'
         );
         expect(patterns.collection.outputPath).to.contain('patterns.html');
-        //console.log(patterns.components.button.collection);
       });
     });
     it ('should prefix with patterns prefix', () => {

--- a/test/write/pages.js
+++ b/test/write/pages.js
@@ -12,30 +12,48 @@ var testUtils = require('../test-utils');
 describe ('write/pages', () => {
   var opts = options(config.fixtureOpts);
   var allData;
-  before (() => {
-    allData = prepare(opts).then(parse).then(render).then(writePages);
-    return allData;
-  });
-  it ('should write page files', () => {
-    return allData.then(drizzleData => {
-      const paths = [
-        drizzleData.pages.doThis.outputPath,
-        drizzleData.pages['04-sandbox'].outputPath
-      ];
-      return testUtils.areFiles(paths).then(allAreFiles => {
-        expect(allAreFiles).to.be.true;
+  describe ('write out page files', () => {
+    before (() => {
+      allData = prepare(opts).then(parse).then(render).then(writePages);
+      return allData;
+    });
+    it ('should write page files', () => {
+      return allData.then(drizzleData => {
+        const paths = [
+          drizzleData.pages.doThis.outputPath,
+          drizzleData.pages['04-sandbox'].outputPath,
+          drizzleData.pages['follow-me'].down.apage.outputPath,
+          drizzleData.pages.subfolder.subpage.outputPath
+        ];
+        return testUtils.areFiles(paths).then(allAreFiles => {
+          expect(allAreFiles).to.be.true;
+        });
+      });
+    });
+    it ('should write page files with compiled contents', () => {
+      allData.then(drizzleData => {
+        return testUtils.fileContents(drizzleData.pages.doThis.outputPath)
+        .then(contents => {
+          expect(contents).to.contain('<h2>foobar</h2>');
+          expect(contents).to.contain('<h1>This is the Page Layout</h1>');
+          expect(contents).not.to.contain('Body content should replace this.');
+        });
       });
     });
   });
-  it ('should write page files with compiled contents', () => {
-    allData.then(drizzleData => {
-      return testUtils.fileContents(drizzleData.pages.doThis.outputPath)
-      .then(contents => {
-        expect(contents).to.contain('<h2>foobar</h2>');
-        expect(contents).to.contain('<h1>This is the Page Layout</h1>');
-        expect(contents).not.to.contain('Body content should replace this.');
+  describe ('write to page destination', () => {
+    var alteredData;
+    before (() => {
+      opts.dest.pages = './test/dist/pageprefixed';
+      alteredData = prepare(opts).then(parse).then(render).then(writePages);
+      return alteredData;
+    });
+    it ('should use dest.pages from options', () => {
+      return alteredData.then(drizzleData => {
+        expect(drizzleData.pages.subfolder.subpage.outputPath).to.contain(
+          'pageprefixed'
+        );
       });
-
     });
   });
 });


### PR DESCRIPTION
BOOOORING PR to refactor some code, add comments, clean up, DRY stuff out and add more tests to the `write` modules.

I was _so_ close to being able to generalize the recursive walking in the `pages` and `collections` write modules, but, just, not so much...too much can o' worms there. Still, not very long functions in either case.