### PR TITLE
Better Error Handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build": "babel src --out-dir dist",
     "coverage": "istanbul cover _mocha -- --recursive",
     "prepublish": "npm run test",
-    "test": "npm run build; mocha --recursive"
+    "test": "npm run build; env DRIZZLE_DEBUG=1 mocha --recursive"
   },
   "keywords": [
     "fabricator"

--- a/src/helpers/pattern.js
+++ b/src/helpers/pattern.js
@@ -18,8 +18,8 @@ function renderPatternPartial (patternId, drizzleData, Handlebars) {
     // Render and return
     return template(localContext);
   } else {
-    new DrizzleError(`Partial for pattern ${patternId} not found`,
-      DrizzleError.LEVELS.ERROR).handle(drizzleData.options.debug);
+    throw new DrizzleError(`Partial for pattern ${patternId} not found`,
+      DrizzleError.LEVELS.ERROR);
   }
 }
 
@@ -29,8 +29,8 @@ function renderPatternPartial (patternId, drizzleData, Handlebars) {
 function registerPatternHelpers (options) {
   const Handlebars = options.handlebars;
   if (Handlebars.helpers.pattern) {
-    new DrizzleError('`pattern` helper already registered',
-      DrizzleError.LEVELS.WARN).handle(options.debug);
+    throw new DrizzleError('`pattern` helper already registered',
+      DrizzleError.LEVELS.WARN);
   }
   /**
    * The `pattern` helper allows the embedding of patterns anywhere
@@ -43,8 +43,8 @@ function registerPatternHelpers (options) {
   });
 
   if (Handlebars.helpers.patternSource) {
-    new DrizzleError('`patternSource` helper already registered',
-      DrizzleError.LEVELS.WARN).handle(options.debug);
+    throw new DrizzleError('`patternSource` helper already registered',
+      DrizzleError.LEVELS.WARN);
   }
   /**
    * Similar to `pattern` but the returned string is HTML-escaped.

--- a/src/helpers/pattern.js
+++ b/src/helpers/pattern.js
@@ -28,8 +28,8 @@ function renderPatternPartial (patternId, drizzleData, Handlebars) {
  */
 function registerPatternHelpers (options) {
   const Handlebars = options.handlebars;
-  if (Handlebars.partials.pattern) {
-    new DrizzleError('`Handlebars.partials.pattern` already registered',
+  if (Handlebars.helpers.pattern) {
+    new DrizzleError('`pattern` helper already registered',
       DrizzleError.LEVELS.WARN).handle(options.debug);
   }
   /**
@@ -42,8 +42,8 @@ function registerPatternHelpers (options) {
     return renderedTemplate;
   });
 
-  if (Handlebars.partials.patternSource) {
-    new DrizzleError('`Handlebars.partials.patternSource` already registered',
+  if (Handlebars.helpers.patternSource) {
+    new DrizzleError('`patternSource` helper already registered',
       DrizzleError.LEVELS.WARN).handle(options.debug);
   }
   /**

--- a/src/helpers/pattern.js
+++ b/src/helpers/pattern.js
@@ -20,7 +20,7 @@ function renderPatternPartial (patternId, drizzleData, Handlebars) {
   } else {
     DrizzleError.error(new DrizzleError(
       `Partial for pattern ${patternId} not found`, DrizzleError.LEVELS.ERROR),
-      drizzleData.options);
+      drizzleData.options.debug);
   }
 }
 
@@ -31,7 +31,7 @@ function registerPatternHelpers (options) {
   const Handlebars = options.handlebars;
   if (Handlebars.helpers.pattern) {
     DrizzleError.error(new DrizzleError('`pattern` helper already registered',
-      DrizzleError.LEVELS.WARN), options);
+      DrizzleError.LEVELS.WARN), options.debug);
   }
   /**
    * The `pattern` helper allows the embedding of patterns anywhere
@@ -46,7 +46,7 @@ function registerPatternHelpers (options) {
   if (Handlebars.helpers.patternSource) {
     DrizzleError.error(new DrizzleError(
       '`patternSource` helper already registered',
-      DrizzleError.LEVELS.WARN), options);
+      DrizzleError.LEVELS.WARN), options.debug);
   }
   /**
    * Similar to `pattern` but the returned string is HTML-escaped.

--- a/src/helpers/pattern.js
+++ b/src/helpers/pattern.js
@@ -18,8 +18,9 @@ function renderPatternPartial (patternId, drizzleData, Handlebars) {
     // Render and return
     return template(localContext);
   } else {
-    throw new DrizzleError(`Partial for pattern ${patternId} not found`,
-      DrizzleError.LEVELS.ERROR);
+    DrizzleError.error(new DrizzleError(
+      `Partial for pattern ${patternId} not found`, DrizzleError.LEVELS.ERROR),
+      drizzleData.options);
   }
 }
 
@@ -29,8 +30,8 @@ function renderPatternPartial (patternId, drizzleData, Handlebars) {
 function registerPatternHelpers (options) {
   const Handlebars = options.handlebars;
   if (Handlebars.helpers.pattern) {
-    throw new DrizzleError('`pattern` helper already registered',
-      DrizzleError.LEVELS.WARN);
+    DrizzleError.error(new DrizzleError('`pattern` helper already registered',
+      DrizzleError.LEVELS.WARN), options);
   }
   /**
    * The `pattern` helper allows the embedding of patterns anywhere
@@ -43,8 +44,9 @@ function registerPatternHelpers (options) {
   });
 
   if (Handlebars.helpers.patternSource) {
-    throw new DrizzleError('`patternSource` helper already registered',
-      DrizzleError.LEVELS.WARN);
+    DrizzleError.error(new DrizzleError(
+      '`patternSource` helper already registered',
+      DrizzleError.LEVELS.WARN), options);
   }
   /**
    * Similar to `pattern` but the returned string is HTML-escaped.

--- a/src/init.js
+++ b/src/init.js
@@ -7,7 +7,7 @@ import Promise from 'bluebird';
  * @param {Object} options
  * @param {Object} handlebars   Handlebars instance—it can be passed explicitly,
  *                              primarily for testing purposes.
- * @return {Object} merged options
+ * @return {Promise} resolving to merged options
  */
 function init (options = {}, handlebars) {
   options.handlebars = handlebars || require('handlebars');

--- a/src/parse/index.js
+++ b/src/parse/index.js
@@ -28,7 +28,7 @@ function parseAll (options) {
         options   : options
       };
     },
-    error => new DrizzleError(error).handle(options.debug)
+    error => DrizzleError.error(error, options)
   );
 }
 

--- a/src/parse/index.js
+++ b/src/parse/index.js
@@ -28,7 +28,7 @@ function parseAll (options) {
         options   : options
       };
     },
-    error => DrizzleError.error(error, options)
+    error => DrizzleError.error(error, options.debug)
   );
 }
 

--- a/src/parse/patterns.js
+++ b/src/parse/patterns.js
@@ -6,6 +6,8 @@ import { readFiles, readFileTree } from '../utils/parse';
 import { titleCase } from '../utils/shared';
 import path from 'path';
 
+import DrizzleError from '../utils/error';
+
 const isPattern = obj => obj.hasOwnProperty('path');
 const collectionPath = itms => path.dirname(itms[Object.keys(itms).pop()].path);
 const collectionKey = itms => collectionPath(itms).split(path.sep).pop();
@@ -187,7 +189,8 @@ function buildCollections (patternObj, options, collectionPromises = []) {
 function parsePatterns (options) {
   return readFileTree(options.src.patterns, options).then(patternObj => {
     return Promise.all(buildCollections(patternObj, options))
-      .then(() => patternObj);
+      .then(() => patternObj,
+            error => DrizzleError.error(error, options));
   });
 }
 

--- a/src/parse/patterns.js
+++ b/src/parse/patterns.js
@@ -190,7 +190,7 @@ function parsePatterns (options) {
   return readFileTree(options.src.patterns, options).then(patternObj => {
     return Promise.all(buildCollections(patternObj, options))
       .then(() => patternObj,
-            error => DrizzleError.error(error, options));
+            error => DrizzleError.error(error, options.debug));
   });
 }
 

--- a/src/prepare/helpers.js
+++ b/src/prepare/helpers.js
@@ -8,6 +8,8 @@ import { getFiles, isGlob } from '../utils/parse';
 import registerPatternHelpers from '../helpers/pattern';
 import handlebarsLayouts from 'handlebars-layouts';
 
+import DrizzleError from '../utils/error';
+
 /**
  * Register helpers on Handlebars. Helpers (options.helpers) can be provided as
  * either:
@@ -55,7 +57,7 @@ function prepareHelpers (options) {
         options.handlebars.registerHelper(helper, helpers[helper]);
       }
       return options;
-    });
+    }, error => DrizzleError.error(error));
 }
 
 export default prepareHelpers;

--- a/src/prepare/helpers.js
+++ b/src/prepare/helpers.js
@@ -57,7 +57,7 @@ function prepareHelpers (options) {
         options.handlebars.registerHelper(helper, helpers[helper]);
       }
       return options;
-    }, error => DrizzleError.error(error, options));
+    }, error => DrizzleError.error(error, options.debug));
 }
 
 export default prepareHelpers;

--- a/src/prepare/helpers.js
+++ b/src/prepare/helpers.js
@@ -57,7 +57,7 @@ function prepareHelpers (options) {
         options.handlebars.registerHelper(helper, helpers[helper]);
       }
       return options;
-    }, error => DrizzleError.error(error));
+    }, error => DrizzleError.error(error, options));
 }
 
 export default prepareHelpers;

--- a/src/prepare/index.js
+++ b/src/prepare/index.js
@@ -20,7 +20,7 @@ function prepare (options) {
     preparePartials(options)
   ]).then(
     () => options,
-    error => new DrizzleError(error).handle(options.debug)
+    error => DrizzleError.error(error, options)
   );
 }
 

--- a/src/prepare/index.js
+++ b/src/prepare/index.js
@@ -20,7 +20,7 @@ function prepare (options) {
     preparePartials(options)
   ]).then(
     () => options,
-    error => DrizzleError.error(error, options)
+    error => DrizzleError.error(error, options.debug)
   );
 }
 

--- a/src/prepare/partials.js
+++ b/src/prepare/partials.js
@@ -41,7 +41,7 @@ function preparePartials (options) {
     registerPartials(options.src.patterns, options, 'patterns') // Patterns
   ]).then(
     () => options,
-    error => DrizzleError.error(error, options)
+    error => DrizzleError.error(error, options.debug)
   );
 }
 

--- a/src/prepare/partials.js
+++ b/src/prepare/partials.js
@@ -20,6 +20,10 @@ function registerPartials (src, options, prefix = '') {
   return readFiles(src.glob, options).then(partialFiles => {
     partialFiles.forEach(partialFile => {
       const partialKey = resourceId(partialFile, src.basedir, prefix);
+      if (options.handlebars.partials.hasOwnProperty(partialKey)) {
+        new DrizzleError(`Duplicate partial key: ${partialKey}`,
+          DrizzleError.LEVELS.WARN).handle(options.debug);
+      }
       options.handlebars.registerPartial(partialKey, partialFile.contents);
     });
   });

--- a/src/prepare/partials.js
+++ b/src/prepare/partials.js
@@ -21,9 +21,9 @@ function registerPartials (src, options, prefix = '') {
     partialFiles.forEach(partialFile => {
       const partialKey = resourceId(partialFile, src.basedir, prefix);
       if (options.handlebars.partials.hasOwnProperty(partialKey)) {
-        throw new DrizzleError(`Partial key '${partialKey}' already
+        DrizzleError.error(new DrizzleError(`Partial key '${partialKey}' already
 registered on Handlebars instance: is this intentional?`,
-          DrizzleError.LEVELS.WARN);
+          DrizzleError.LEVELS.WARN), options);
       }
       options.handlebars.registerPartial(partialKey, partialFile.contents);
     });

--- a/src/prepare/partials.js
+++ b/src/prepare/partials.js
@@ -21,9 +21,9 @@ function registerPartials (src, options, prefix = '') {
     partialFiles.forEach(partialFile => {
       const partialKey = resourceId(partialFile, src.basedir, prefix);
       if (options.handlebars.partials.hasOwnProperty(partialKey)) {
-        new DrizzleError(`Partial key '${partialKey}' already registered on
-Handlebars instance: is this intentional?`,
-          DrizzleError.LEVELS.WARN).handle(options.debug);
+        throw new DrizzleError(`Partial key '${partialKey}' already
+registered on Handlebars instance: is this intentional?`,
+          DrizzleError.LEVELS.WARN);
       }
       options.handlebars.registerPartial(partialKey, partialFile.contents);
     });
@@ -41,7 +41,7 @@ function preparePartials (options) {
     registerPartials(options.src.patterns, options, 'patterns') // Patterns
   ]).then(
     () => options,
-    error => DrizzleError.error(error)
+    error => DrizzleError.error(error, options)
   );
 }
 

--- a/src/prepare/partials.js
+++ b/src/prepare/partials.js
@@ -21,7 +21,8 @@ function registerPartials (src, options, prefix = '') {
     partialFiles.forEach(partialFile => {
       const partialKey = resourceId(partialFile, src.basedir, prefix);
       if (options.handlebars.partials.hasOwnProperty(partialKey)) {
-        new DrizzleError(`Duplicate partial key: ${partialKey}`,
+        new DrizzleError(`Partial key '${partialKey}' already registered on
+Handlebars instance: is this intentional?`,
           DrizzleError.LEVELS.WARN).handle(options.debug);
       }
       options.handlebars.registerPartial(partialKey, partialFile.contents);
@@ -40,7 +41,8 @@ function preparePartials (options) {
     registerPartials(options.src.patterns, options, 'patterns') // Patterns
   ]).then(
     () => options,
-    error => new DrizzleError(error).handle(options.debug));
+    error => DrizzleError.error(error)
+  );
 }
 
 export default preparePartials;

--- a/src/render/index.js
+++ b/src/render/index.js
@@ -21,7 +21,7 @@ function render (drizzleData) {
       templates : drizzleData.templates,
       options : drizzleData.options
     };
-  }, error => new DrizzleError(error).handle(drizzleData.options.debug));
+  }, error => DrizzleError.error(error, drizzleData.options));
 }
 
 export default render;

--- a/src/render/index.js
+++ b/src/render/index.js
@@ -21,7 +21,7 @@ function render (drizzleData) {
       templates : drizzleData.templates,
       options : drizzleData.options
     };
-  }, error => DrizzleError.error(error, drizzleData.options));
+  }, error => DrizzleError.error(error, drizzleData.options.debug));
 }
 
 export default render;

--- a/src/utils/error.js
+++ b/src/utils/error.js
@@ -6,15 +6,30 @@ function DrizzleError (message, level) {
 
 DrizzleError.prototype = Object.create(Error.prototype);
 
+/**
+ * Handle an error by logging or throwing it. Will always throw if
+ * debug env set (DRIZZLE_DEBUG).
+ */
 DrizzleError.prototype.handle = function (options = {}) {
   options = Object.assign({
     logFn: console.log,
-    throwThreshold: (process.env.DRIZZLE_DEBUG) ? 0 : DrizzleError.LEVELS.ERROR
+    throwThreshold: DrizzleError.LEVELS.ERROR
   }, options);
-  if (this.level >= options.throwThreshold) {
+  if (this.level >= options.throwThreshold || process.env.DRIZZLE_DEBUG) {
     throw this;
   }
   options.logFn(this.message);
+};
+
+/**
+ * This static method allows DrizzleError to handle things that may not
+ * be DrizzleErrors yet (e.g. they're Errors).
+ */
+DrizzleError.error = function (error, options = {}) {
+  if (!(error instanceof DrizzleError)) {
+    error = new DrizzleError(error, DrizzleError.LEVELS.ERROR);
+  }
+  error.handle(options);
 };
 
 DrizzleError.LEVELS = {

--- a/src/utils/error.js
+++ b/src/utils/error.js
@@ -7,29 +7,21 @@ function DrizzleError (message, level) {
 DrizzleError.prototype = Object.create(Error.prototype);
 
 /**
- * Handle an error by logging or throwing it. Will always throw if
- * debug env set (DRIZZLE_DEBUG).
- */
-DrizzleError.prototype.handle = function (options = {}) {
-  options = Object.assign({
-    logFn: console.log,
-    throwThreshold: DrizzleError.LEVELS.ERROR
-  }, options);
-  if (this.level >= options.throwThreshold || process.env.DRIZZLE_DEBUG) {
-    throw this;
-  }
-  options.logFn(this.message);
-};
-
-/**
  * This static method allows DrizzleError to handle things that may not
  * be DrizzleErrors yet (e.g. they're Errors).
  */
 DrizzleError.error = function (error, options = {}) {
+  options.debug = Object.assign({
+    logFn: console.log,
+    throwThreshold: DrizzleError.LEVELS.ERROR
+  }, options.debug || {});
   if (!(error instanceof DrizzleError)) {
     error = new DrizzleError(error, DrizzleError.LEVELS.ERROR);
   }
-  error.handle(options);
+  if (this.level >= options.throwThreshold || process.env.DRIZZLE_DEBUG) {
+    throw error;
+  }
+  options.debug.logFn(error.message);
 };
 
 DrizzleError.LEVELS = {

--- a/src/utils/error.js
+++ b/src/utils/error.js
@@ -18,7 +18,7 @@ DrizzleError.error = function (error, options = {}) {
   if (!(error instanceof DrizzleError)) {
     error = new DrizzleError(error, DrizzleError.LEVELS.ERROR);
   }
-  if (this.level >= options.throwThreshold) {
+  if (error.level >= options.throwThreshold) {
     throw error;
   }
   options.logFn(error.message);

--- a/src/utils/error.js
+++ b/src/utils/error.js
@@ -9,7 +9,7 @@ DrizzleError.prototype = Object.create(Error.prototype);
 DrizzleError.prototype.handle = function (options = {}) {
   options = Object.assign({
     logFn: console.log,
-    throwThreshold: DrizzleError.LEVELS.ERROR
+    throwThreshold: (process.env.DRIZZLE_DEBUG) ? 0 : DrizzleError.LEVELS.ERROR
   }, options);
   if (this.level >= options.throwThreshold) {
     throw this;

--- a/src/utils/error.js
+++ b/src/utils/error.js
@@ -11,17 +11,17 @@ DrizzleError.prototype = Object.create(Error.prototype);
  * be DrizzleErrors yet (e.g. they're Errors).
  */
 DrizzleError.error = function (error, options = {}) {
-  options.debug = Object.assign({
+  options = Object.assign({
     logFn: console.log,
-    throwThreshold: DrizzleError.LEVELS.ERROR
-  }, options.debug || {});
+    throwThreshold: (process.env.DRIZZLE_DEBUG) ? 0 : DrizzleError.LEVELS.ERROR
+  }, options || {});
   if (!(error instanceof DrizzleError)) {
     error = new DrizzleError(error, DrizzleError.LEVELS.ERROR);
   }
-  if (this.level >= options.throwThreshold || process.env.DRIZZLE_DEBUG) {
+  if (this.level >= options.throwThreshold) {
     throw error;
   }
-  options.debug.logFn(error.message);
+  options.logFn(error.message);
 };
 
 DrizzleError.LEVELS = {

--- a/src/utils/object.js
+++ b/src/utils/object.js
@@ -18,8 +18,9 @@ function deepObj (pathKeys, obj, createEntries = true) {
       if (createEntries) {
         prev[curr] = {};
       } else {
-        throw new DrizzleError(`Property ${curr} not found on supplied object`,
-          DrizzleError.LEVELS.ERROR);
+        DrizzleError.error(new DrizzleError(
+          `Property ${curr} not found on supplied object`,
+          DrizzleError.LEVELS.ERROR));
       }
     }
     return prev[curr];
@@ -49,8 +50,8 @@ function deepPattern (patternId, obj) {
  * in the object `obj`.
  * @see deepPattern
  */
-function deepCollection (patternId, obj) {
-  const pathBits = patternId.split('.'); // TODO pattern separator elsewhere?
+function deepCollection (collectionId, obj) {
+  const pathBits = collectionId.split('.'); // TODO pattern separator elsewhere?
   pathBits.pop();
   pathBits.push('collection');
   pathBits.shift();

--- a/src/utils/object.js
+++ b/src/utils/object.js
@@ -1,5 +1,7 @@
 import { keyname, relativePathArray } from './shared';
 
+import DrizzleError from './error';
+
 /**
  * Return a reference to the deeply-nested object indicated by the items
  * in `pathKeys`. If `createEntries`, entry levels will be created as needed
@@ -16,7 +18,8 @@ function deepObj (pathKeys, obj, createEntries = true) {
       if (createEntries) {
         prev[curr] = {};
       } else {
-        throw new Error(`Property ${curr} not found on supplied object`);
+        throw new DrizzleError(`Property ${curr} not found on supplied object`,
+          DrizzleError.LEVELS.ERROR);
       }
     }
     return prev[curr];

--- a/src/utils/parse.js
+++ b/src/utils/parse.js
@@ -1,10 +1,10 @@
 import globby from 'globby';
-import marked from 'marked';
 import Promise from 'bluebird';
 import {readFile as readFileCB} from 'fs';
 var readFile = Promise.promisify(readFileCB);
 import { relativePathArray } from './shared';
 import { deepObj, resourceKey } from './object'; // TODO NO NO NO NO NO
+import DrizzleError from './error';
 
 /**
  * @param {glob} glob
@@ -81,7 +81,10 @@ function parseField (fieldKey, fieldData, options) {
     if (options.parsers.hasOwnProperty(fieldData.parser)) {
       parseFn = options.parsers[fieldData.parser].parseFn;
     }
-    else { // TODO Handle error
+    else {
+      DrizzleError.error(new DrizzleError(
+        `parser '${fieldData.parser}' set on field '${fieldKey}' not defined`,
+        DrizzleError.LEVELS.WARN), options);
     }
     contents = fieldData.contents;
     if (!fieldData.hasOwnProperty('contents')) {

--- a/src/utils/parse.js
+++ b/src/utils/parse.js
@@ -84,7 +84,7 @@ function parseField (fieldKey, fieldData, options) {
     else {
       DrizzleError.error(new DrizzleError(
         `parser '${fieldData.parser}' set on field '${fieldKey}' not defined`,
-        DrizzleError.LEVELS.WARN), options);
+        DrizzleError.LEVELS.WARN), options.debug);
     }
     contents = fieldData.contents;
     if (!fieldData.hasOwnProperty('contents')) {

--- a/src/write/collections.js
+++ b/src/write/collections.js
@@ -1,4 +1,5 @@
 import { writeResource } from '../utils/write';
+import DrizzleError from '../utils/error';
 
 const hasCollection = patterns => patterns.hasOwnProperty('collection');
 const isCollection = patterns => patterns.hasOwnProperty('items');
@@ -41,7 +42,8 @@ function writeCollections (drizzleData) {
     drizzleData.patterns,
     drizzleData,
     [drizzleData.options.src.patterns.basedir])
-  ).then(writePromises => drizzleData);
+  ).then(writePromises => drizzleData,
+         error => DrizzleError.error(error, drizzleData.options));
 }
 
 export default writeCollections;

--- a/src/write/collections.js
+++ b/src/write/collections.js
@@ -43,7 +43,7 @@ function writeCollections (drizzleData) {
     drizzleData,
     [drizzleData.options.src.patterns.basedir])
   ).then(writePromises => drizzleData,
-         error => DrizzleError.error(error, drizzleData.options));
+         error => DrizzleError.error(error, drizzleData.options.debug));
 }
 
 export default writeCollections;

--- a/src/write/index.js
+++ b/src/write/index.js
@@ -15,7 +15,7 @@ function write (drizzleData) {
     writeCollections(drizzleData)
   ]).then(
     () => drizzleData,
-    error => new DrizzleError(error).handle(drizzleData.options.debug)
+    error => DrizzleError.error(error, drizzleData.options)
   );
 }
 

--- a/src/write/pages.js
+++ b/src/write/pages.js
@@ -37,7 +37,7 @@ function walkPages (pages, drizzleData, currentKeys = [], writePromises = []) {
 function writePages (drizzleData) {
   return Promise.all(walkPages(drizzleData.pages, drizzleData))
     .then(() => drizzleData,
-          error => DrizzleError.error(error, drizzleData.options));
+          error => DrizzleError.error(error, drizzleData.options.debug));
 }
 
 export default writePages;

--- a/src/write/pages.js
+++ b/src/write/pages.js
@@ -1,4 +1,5 @@
 import { writeResource } from '../utils/write';
+import DrizzleError from '../utils/error';
 
 const isPage = page => page.hasOwnProperty('contents');
 
@@ -35,7 +36,8 @@ function walkPages (pages, drizzleData, currentKeys = [], writePromises = []) {
  */
 function writePages (drizzleData) {
   return Promise.all(walkPages(drizzleData.pages, drizzleData))
-    .then(() => drizzleData);
+    .then(() => drizzleData,
+          error => DrizzleError.error(error, drizzleData.options));
 }
 
 export default writePages;

--- a/test/config.js
+++ b/test/config.js
@@ -3,7 +3,9 @@ var yaml = require('js-yaml');
 var frontMatter = require('front-matter');
 var marked = require('marked');
 
-var init = require('../dist/init');
+var drizzleInit = require('../dist/init');
+
+var Handlebars = require('handlebars');
 
 const fixtures = path.join(__dirname, 'fixtures/');
 const parsers = {
@@ -42,6 +44,14 @@ const parsers = {
 
 function fixturePath (glob) {
   return path.normalize(path.join(fixtures, glob));
+}
+
+function init (options) {
+  options = options || config.fixtureOpts;
+  return drizzleInit(options).then(opts => {
+    opts.handlebars = Handlebars.create();
+    return opts;
+  });
 }
 
 var config = {

--- a/test/prepare/helpers.js
+++ b/test/prepare/helpers.js
@@ -5,7 +5,7 @@ var prepareHelpers = require('../../dist/prepare/helpers');
 
 var DrizzleError = require('../../dist/utils/error');
 
-describe.only ('prepare/helpers', () => {
+describe ('prepare/helpers', () => {
   describe ('default helpers', () => {
     var preparedOptions;
     before(() => {

--- a/test/prepare/index.js
+++ b/test/prepare/index.js
@@ -1,22 +1,24 @@
 var chai = require('chai');
 var config = require('../config');
 var expect = chai.expect;
-var init = require('../../dist/init');
 var prepare = require('../../dist/prepare/');
 
 describe ('prepare/index', () => {
   var opts;
   beforeEach(() => {
-    opts = init(config.fixtureOpts);
+    return config.init(config.fixtureOpts).then(options => {
+      opts = options;
+      return opts;
+    });
   });
   it ('should resolve to an options object', () => {
-    return opts.then(prepare).then(preparedOpts => {
+    return prepare(opts).then(preparedOpts => {
       expect(preparedOpts).to.be.an('object');
       expect(preparedOpts).to.contain.keys('handlebars');
     });
   });
   it ('should prepare helpers', () => {
-    return opts.then(prepare).then(preparedOpts => {
+    return prepare(opts).then(preparedOpts => {
       expect(preparedOpts.handlebars.helpers).to.contain.keys(
         'toFraction', 'toJSON', 'toSlug'
       );
@@ -26,14 +28,14 @@ describe ('prepare/index', () => {
     });
   });
   it ('should register layouts as partials', () => {
-    return opts.then(prepare).then(preparedOpts => {
+    return prepare(opts).then(preparedOpts => {
       expect(preparedOpts.handlebars.partials).to.contain.keys(
         'default', 'page', 'collection'
       );
     });
   });
   it ('should prepare partials', () => {
-    return opts.then(prepare).then(preparedOpts => {
+    return prepare(opts).then(preparedOpts => {
       expect(preparedOpts.handlebars.partials).to.contain.keys(
         'partials.header', 'partials.menu'
       );
@@ -43,7 +45,7 @@ describe ('prepare/index', () => {
     });
   });
   it ('should prepare pattern partials', () => {
-    return opts.then(prepare).then(preparedOpts => {
+    return prepare(opts).then(preparedOpts => {
       expect(preparedOpts.handlebars.partials).to.contain.keys(
         'patterns.pink',
         'patterns.components.button.base',
@@ -52,7 +54,7 @@ describe ('prepare/index', () => {
     });
   });
   it ('should register the `pattern` helper', () => {
-    return opts.then(prepare).then(preparedOpts => {
+    return prepare(opts).then(preparedOpts => {
       expect(preparedOpts.handlebars.helpers).to.contain.key('pattern');
     });
   });

--- a/test/prepare/partials.js
+++ b/test/prepare/partials.js
@@ -1,13 +1,12 @@
 var chai = require('chai');
 var config = require('../config');
 var expect = chai.expect;
-var init = require('../../dist/init');
 var preparePartials = require('../../dist/prepare/partials');
 
 describe ('prepare/partials', () => {
   var options;
-  before(() => {
-    return init(config.fixtureOpts).then(preparePartials).then(pOpts => {
+  beforeEach(() => {
+    return config.init(config.fixtureOpts).then(preparePartials).then(pOpts => {
       options = pOpts;
     });
   });

--- a/test/prepare/partials.js
+++ b/test/prepare/partials.js
@@ -3,28 +3,48 @@ var config = require('../config');
 var expect = chai.expect;
 var preparePartials = require('../../dist/prepare/partials');
 
+var DrizzleError = require('../../dist/utils/error');
+
 describe ('prepare/partials', () => {
   var options;
-  beforeEach(() => {
-    return config.init(config.fixtureOpts).then(preparePartials).then(pOpts => {
-      options = pOpts;
+  describe ('registering partials', () => {
+    beforeEach(() => {
+      return config.init(config.fixtureOpts)
+      .then(preparePartials).then(pOpts => {
+        options = pOpts;
+      });
+    });
+    it ('should register layout partials', () => {
+      expect(options.handlebars.partials).to.contain.keys(
+        'collection', 'default', 'page');
+    });
+    it ('should register partials', () => {
+      expect(options.handlebars.partials).to.contain.keys(
+        'partials.header', 'partials.menu', 'partials.nested.thing');
+    });
+    it ('should register patterns files as partials', () => {
+      expect(options.handlebars.partials).to.contain.keys(
+        'patterns.components.orange', 'patterns.components.button.aardvark');
+      expect(options.handlebars.partials).to.contain.keys(
+        'patterns.pink',
+        'patterns.components.button.base',
+        'patterns.components.button.color-variation'
+      );
     });
   });
-  it ('should register layout partials', () => {
-    expect(options.handlebars.partials).to.contain.keys(
-      'collection', 'default', 'page');
-  });
-  it ('should register partials', () => {
-    expect(options.handlebars.partials).to.contain.keys(
-      'partials.header', 'partials.menu', 'partials.nested.thing');
-  });
-  it ('should register patterns files as partials', () => {
-    expect(options.handlebars.partials).to.contain.keys(
-      'patterns.components.orange', 'patterns.components.button.aardvark');
-    expect(options.handlebars.partials).to.contain.keys(
-      'patterns.pink',
-      'patterns.components.button.base',
-      'patterns.components.button.color-variation'
-    );
+  describe ('reporting errors', () => {
+    var options;
+    before (() => {
+      return config.init(config.fixtureOpts).then(preparePartials)
+        .then(pOpts => {
+          options = pOpts;
+        });
+    });
+    it ('should log error if duplicate partial encountered', () => {
+      return preparePartials(options).catch(error => {
+        expect(error).to.contain.key('message');
+        expect(error).to.be.an.instanceOf(DrizzleError);
+      });
+    });
   });
 });

--- a/test/utils/error.js
+++ b/test/utils/error.js
@@ -32,18 +32,14 @@ describe ('utils/error', () => {
         it ('should use a default throw threshold on `handle`', () => {
           const error = new DrizzleError('random error',
             DrizzleError.LEVELS.ERROR);
-          expect(error.handle.bind(error)).to.throw;
+          expect(DrizzleError.error.bind(DrizzleError, error))
+            .to.throw(DrizzleError);
         });
         it ('should not throw if below threshold', () => {
           const error = new DrizzleError('random error',
             DrizzleError.LEVELS.NOTICE);
-          expect(error.handle.bind(error)).not.to.throw;
-        });
-        it ('should take a threshold', () => {
-          const error = new DrizzleError('random error',
-            DrizzleError.LEVELS.NOTICE);
-          expect(error.handle.bind(error,
-            { throwThreshold: DrizzleError.LEVELS.NOTICE })).to.throw;
+          expect(DrizzleError.error.bind(DrizzleError, error))
+            .to.throw(DrizzleError);
         });
       });
     });
@@ -51,7 +47,8 @@ describe ('utils/error', () => {
   describe('debugging', () => {
     it ('should throw all errors by default in debug', () => {
       const error = new DrizzleError('random error');
-      expect (error.handle.bind(error)).to.throw;
+      expect(DrizzleError.error.bind(DrizzleError, error))
+        .to.throw(DrizzleError);
     });
     it ('should by default log to console on non-throw errors');
     it ('should accept a logging function');

--- a/test/utils/error.js
+++ b/test/utils/error.js
@@ -1,4 +1,3 @@
-/* global describe, it */
 var chai = require('chai');
 var expect = chai.expect;
 chai.use(expect);
@@ -48,8 +47,13 @@ describe ('utils/error', () => {
         });
       });
     });
+  });
+  describe('debugging', () => {
+    it ('should throw all errors by default in debug', () => {
+      const error = new DrizzleError('random error');
+      expect (error.handle.bind(error)).to.throw;
+    });
     it ('should by default log to console on non-throw errors');
     it ('should accept a logging function');
-    it ('should throw by default on ERROR');
   });
 });

--- a/test/utils/error.js
+++ b/test/utils/error.js
@@ -1,8 +1,10 @@
 var chai = require('chai');
 var expect = chai.expect;
 chai.use(expect);
+var sinon = require('sinon');
+var sinonChai = require('sinon-chai');
+chai.use(sinonChai);
 var DrizzleError = require('../../dist/utils/error');
-//chai.use(sinonChai);
 
 describe ('utils/error', () => {
   describe ('instantiation and class', () => {
@@ -43,6 +45,9 @@ describe ('utils/error', () => {
         });
       });
     });
+    describe ('logging', () => {
+      it ('should properly format error messages');
+    });
   });
   describe('debugging', () => {
     it ('should throw all errors by default in debug', () => {
@@ -50,7 +55,21 @@ describe ('utils/error', () => {
       expect(DrizzleError.error.bind(DrizzleError, error))
         .to.throw(DrizzleError);
     });
-    it ('should by default log to console on non-throw errors');
-    it ('should accept a logging function');
+    it ('should by default log to console on non-throw errors', () => {
+      const error = new DrizzleError('random error', DrizzleError.LEVELS.WARN);
+      const debugOpts = { throwThreshold: 5 };
+      expect(DrizzleError.error.bind(DrizzleError, error, debugOpts))
+        .not.to.throw;
+    });
+    it ('should accept a logging function', () => {
+      const error = new DrizzleError('random error', DrizzleError.LEVELS.WARN);
+      const logFn = sinon.stub();
+      const debugOpts = {
+        throwThreshold: 5,
+        logFn: logFn
+      };
+      DrizzleError.error(error, debugOpts);
+      expect(logFn).to.have.been.calledOnce;
+    });
   });
 });

--- a/test/utils/object.js
+++ b/test/utils/object.js
@@ -3,8 +3,9 @@ var chai = require('chai');
 var expect = chai.expect;
 //var config = require('./config');
 var utils = require('../../dist/utils/object');
+var DrizzleError = require('../../dist/utils/error');
 
-describe ('utils/object', () => {
+describe.only ('utils/object', () => {
   describe('deepCollection', () => {
     it ('should return deep collection', () => {
       var patternsObj = {
@@ -28,7 +29,7 @@ describe ('utils/object', () => {
     it ('should throw if collection path non-extant', () => {
       const obj = {foo : {}};
       expect(utils.deepCollection.bind(
-        utils, ('foo.bar.baz', obj, false))).to.throw;
+        utils, 'foo.bar.baz', obj, false)).to.throw(DrizzleError);
     });
   });
   describe('deepObj', () => {
@@ -41,7 +42,7 @@ describe ('utils/object', () => {
     it ('should not create paths when indicated', () => {
       const obj = {foo : {}};
       expect(utils.deepObj.bind(
-        utils, (['foo', 'bar', 'baz'], obj, false))).to.throw;
+        utils, ['foo', 'bar', 'baz'], obj, false)).to.throw(DrizzleError);
     });
   });
   describe('deepPattern', () => {
@@ -66,7 +67,7 @@ describe ('utils/object', () => {
     it ('should throw if pattern path non-extant', () => {
       const obj = {foo : {}};
       expect(utils.deepPattern.bind(
-        utils, ('foo.bar.baz', obj, false))).to.throw;
+        utils, 'foo.bar.baz', obj, false)).to.throw(DrizzleError);
     });
   });
 

--- a/test/utils/object.js
+++ b/test/utils/object.js
@@ -5,7 +5,7 @@ var expect = chai.expect;
 var utils = require('../../dist/utils/object');
 var DrizzleError = require('../../dist/utils/error');
 
-describe.only ('utils/object', () => {
+describe ('utils/object', () => {
   describe('deepCollection', () => {
     it ('should return deep collection', () => {
       var patternsObj = {

--- a/test/write/collections.js
+++ b/test/write/collections.js
@@ -5,13 +5,13 @@ var prepare = require('../../dist/prepare/');
 var parse = require('../../dist/parse/');
 var render = require('../../dist/render/');
 var writePatterns = require('../../dist/write/collections');
-var init = require('../../dist/init');
 var testUtils = require('../test-utils');
 
 describe ('write/collections', () => {
   var drizzleData;
   before (() => {
-    return init(config.fixtureOpts).then(prepare).then(parse).then(render)
+    return config.init(config.fixtureOpts)
+      .then(prepare).then(parse).then(render)
       .then(writePatterns).then(aData => {
         drizzleData = aData;
         return drizzleData;


### PR DESCRIPTION
This PR introduces some sort of consistent error handling across the package.

* `npm test` now adds an environment variable (`DRIZZLE_DEBUG`) which is used to make all errors throw by default. This aids in testability.
* `DrizzleError` extends `Error`. Errors can also be dispatched with a static method, `DrizzleError.error`.
* Several places will spawn WARN errors now—duplicate partial keys will be noted, e.g.
* Promise chains have `catch` functions now, which use `DrizzleError` to handle errors that arise.
* Tests pass and additional tests have been added for `utils/error`.
* Several pending tests fulfilled now.