### PR TITLE
Nav Tree Structure

### DIFF
--- a/src/defaults.js
+++ b/src/defaults.js
@@ -10,6 +10,7 @@ const defaults = {
     logFn: console.log
   },
   dest          : {
+    collections: './dist/patterns',
     pages   : './dist/pages',
     patterns: './dist/patterns'
   },

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -45,11 +45,26 @@ const defaults = {
  * change in common usage.
  */
 defaults.keys = {
-  pages      : 'pages',
-  patterns   : 'patterns',
-  collections: 'collections',
-  data       : 'data',
-  templates  : 'templates'
+  collections: {
+    singular: 'collection',
+    plural: 'collections'
+  },
+  data: {
+    singular: 'data',
+    plural: 'data'
+  },
+  pages      : {
+    singular: 'page',
+    plural: 'pages'
+  },
+  patterns   : {
+    singular: 'pattern',
+    plural: 'patterns'
+  },
+  templates  : {
+    singular: 'template',
+    plural: 'templates'
+  }
 };
 
 export default defaults;

--- a/src/parse/index.js
+++ b/src/parse/index.js
@@ -6,6 +6,8 @@ import parsePages from './pages';
 import parsePatterns from './patterns';
 import parseTemplates from './templates';
 
+import parseTree from './tree';
+
 import DrizzleError from '../utils/error';
 /**
  * Parse files with data from src and build a drizzleData object
@@ -18,16 +20,7 @@ function parseAll (options) {
     parsePages(options),
     parsePatterns(options),
     parseTemplates(options)
-  ]).then(
-    allData => {
-      return {
-        data      : allData[0],
-        pages     : allData[1],
-        patterns  : allData[2],
-        templates : allData[3],
-        options   : options
-      };
-    },
+  ]).then(allData => parseTree(allData, options),
     error => DrizzleError.error(error, options.debug)
   );
 }

--- a/src/parse/patterns.js
+++ b/src/parse/patterns.js
@@ -162,8 +162,9 @@ function buildCollection (collectionObj, options) {
     const collectionMeta = (collData.length) ? collData[0].contents : {};
     collectionObj.collection = Object.assign ({
       name: titleCase(collectionKey(items)),
+      resourceType: options.keys.collections.singular,
       id: resourceId(pseudoFile, options.src.patterns.basedir,
-        options.keys.collections)
+        options.keys.collections.plural)
     }, collectionMeta);
     checkNamespaceCollision(['items', 'patterns'], collectionObj.collection,
       `Collection ${collectionObj.collection.name}`, options);

--- a/src/parse/tree.js
+++ b/src/parse/tree.js
@@ -3,6 +3,8 @@
  * @module parse/tree
  */
 
+import { resourcePath } from '../utils/shared';
+
 /**
 return {
   data      : allData[0],
@@ -16,12 +18,13 @@ return {
 function walkResources (resources, options, resourceType, resourceTree = {}) {
   for (var resourceKey in resources) {
     if (resources[resourceKey].resourceType &&
-      resources[resourceKey].resourceType === resourceType) {
+      resources[resourceKey].resourceType === resourceType.singular) {
       resourceTree.items = resourceTree.items || [];
       resourceTree.items.push({
         id: resources[resourceKey].id,
         key: resourceKey,
-        resource: resources[resourceKey]
+        path: resourcePath(resources[resourceKey].id,
+          options.dest[resourceType.plural], options)
       });
     } else {
       resourceTree.children = resourceTree.children || [];
@@ -41,9 +44,9 @@ function parseTree (allData, options) {
     patterns : allData[2],
     templates: allData[3],
     tree: {
-      pages: walkResources(allData[1], options, options.keys.pages.singular),
+      pages: walkResources(allData[1], options, options.keys.pages),
       collections: walkResources(
-        allData[2], options, options.keys.collections.singular)
+        allData[2], options, options.keys.collections)
     },
     options  : options
   };

--- a/src/parse/tree.js
+++ b/src/parse/tree.js
@@ -1,0 +1,28 @@
+/**
+ * Build an object representing the upcoming output tree
+ * @module parse/tree
+ */
+
+/**
+return {
+  data      : allData[0],
+  pages     : allData[1],
+  patterns  : allData[2],
+  templates : allData[3],
+  options   : options
+};
+**/
+
+function parseTree (allData, options) {
+  const dataObj = {
+    data     : allData[0],
+    pages    : allData[1],
+    patterns : allData[2],
+    templates: allData[3],
+    options  : options
+  };
+  return dataObj;
+}
+
+
+export default parseTree;

--- a/src/parse/tree.js
+++ b/src/parse/tree.js
@@ -13,12 +13,38 @@ return {
 };
 **/
 
+function walkResources (resources, options, resourceType, resourceTree = {}) {
+  for (var resourceKey in resources) {
+    if (resources[resourceKey].resourceType &&
+      resources[resourceKey].resourceType === resourceType) {
+      resourceTree.items = resourceTree.items || [];
+      resourceTree.items.push({
+        id: resources[resourceKey].id,
+        key: resourceKey,
+        resource: resources[resourceKey]
+      });
+    } else {
+      resourceTree.children = resourceTree.children || [];
+      resourceTree.children.push(
+        walkResources(resources[resourceKey], options,
+          resourceType, resourceTree[resourceKey])
+      );
+    }
+  }
+  return resourceTree;
+}
+
 function parseTree (allData, options) {
   const dataObj = {
     data     : allData[0],
     pages    : allData[1],
     patterns : allData[2],
     templates: allData[3],
+    tree: {
+      pages: walkResources(allData[1], options, options.keys.pages.singular),
+      collections: walkResources(
+        allData[2], options, options.keys.collections.singular)
+    },
     options  : options
   };
   return dataObj;

--- a/src/render/index.js
+++ b/src/render/index.js
@@ -19,7 +19,8 @@ function render (drizzleData) {
       pages   : allData[0],
       patterns: allData[1],
       templates : drizzleData.templates,
-      options : drizzleData.options
+      options : drizzleData.options,
+      tree: drizzleData.tree
     };
   }, error => DrizzleError.error(error, drizzleData.options.debug));
 }

--- a/src/utils/parse.js
+++ b/src/utils/parse.js
@@ -175,7 +175,8 @@ function readFileTree (src, prefix, options) {
   return readFiles(src.glob, options).then(fileData => {
     fileData.forEach(itemFile => {
       const fileKeys = relativePathArray(itemFile.path, src.basedir);
-      itemFile.id = resourceId(itemFile, src.basedir, prefix);
+      itemFile.id = resourceId(itemFile, src.basedir, prefix.plural);
+      itemFile.resourceType = prefix.singular;
       deepObj(fileKeys, fileTree)[resourceKey(itemFile)] = parseLocalData(
         itemFile, options);
     });

--- a/src/utils/shared.js
+++ b/src/utils/shared.js
@@ -41,6 +41,21 @@ function relativePathArray (filePath, fromPath) {
 }
 
 /**
+ *
+ */
+function resourcePath (resourceId, dest, options) {
+  const subPath = idKeys(resourceId);
+  subPath.shift();
+  const filename = subPath.pop() + '.html';
+  const outputPath = path.normalize(path.join(
+    dest,
+    subPath.join(path.sep),
+    filename
+  ));
+  return outputPath;
+}
+
+/**
  * Convert str to title case (every word will be capitalized)
  * @param {String} str
  * @return {String}
@@ -55,5 +70,6 @@ function titleCase (str) {
 export { idKeys,
          keyname,
          relativePathArray,
+         resourcePath,
          titleCase
        };

--- a/src/utils/shared.js
+++ b/src/utils/shared.js
@@ -46,10 +46,14 @@ function relativePathArray (filePath, fromPath) {
  * @param {String} dest         This path will be prepended
  * @return {String} path
  */
-function resourcePath (resourceId, dest) {
+function resourcePath (resourceId, dest = '') {
   const subPath = idKeys(resourceId);
   // Remove first item because it is the "resource type"
-  subPath.shift();
+  // If there _is_ only one item in the ID, it will be left alone
+  // To serve as the filename.
+  if (subPath.length && subPath.length > 1) {
+    subPath.shift();
+  }
   const filename = subPath.pop() + '.html';
   const outputPath = path.normalize(path.join(
     dest,

--- a/src/utils/shared.js
+++ b/src/utils/shared.js
@@ -41,10 +41,14 @@ function relativePathArray (filePath, fromPath) {
 }
 
 /**
- *
+ * Generate a path for a resource based on its ID.
+ * @param {String} resourceId   '.'-separated ID for this resource
+ * @param {String} dest         This path will be prepended
+ * @return {String} path
  */
-function resourcePath (resourceId, dest, options) {
+function resourcePath (resourceId, dest) {
   const subPath = idKeys(resourceId);
+  // Remove first item because it is the "resource type"
   subPath.shift();
   const filename = subPath.pop() + '.html';
   const outputPath = path.normalize(path.join(

--- a/src/utils/write.js
+++ b/src/utils/write.js
@@ -2,7 +2,7 @@ import path from 'path';
 import Promise from 'bluebird';
 import {writeFile as writeFileCB} from 'fs';
 import {mkdirp as mkdirpCB} from 'mkdirp';
-import { idKeys } from './shared';
+import { resourcePath } from './shared';
 var writeFile = Promise.promisify(writeFileCB);
 var mkdirp    = Promise.promisify(mkdirpCB);
 
@@ -27,24 +27,10 @@ function write (filepath, contents) {
  * @param {Object} resourceObj  The object to output. Must have `contents` prop
  * @param {String} pathPrefix   The output path prefix (as defined in
  *                              options.dest—@see defaults).
- * @param {String} idPrefix     Expected resource-type prefix on ID string. This
- *                              string will be removed from the front of the
- *                              path. E.g. a resourceId of `pages.one.two`
- *                              and `idPrefix` of `pages` will remove the
- *                              'pages' entry from the path.
  * @return {Promise}
  */
-function writePage (resourceId, resourceObj, pathPrefix, idPrefix = '') {
-  const subPath = idKeys(resourceId);
-  if (subPath.length && idPrefix && subPath[0] === idPrefix) {
-    subPath.shift();
-  }
-  const filename = subPath.pop() + '.html';
-  const outputPath = path.normalize(path.join(
-    pathPrefix,
-    subPath.join(path.sep),
-    filename
-  ));
+function writePage (resourceId, resourceObj, pathPrefix) {
+  const outputPath = resourcePath(resourceId, pathPrefix);
   resourceObj.outputPath = outputPath;
   return write(outputPath, resourceObj.contents);
 }

--- a/src/write/collections.js
+++ b/src/write/collections.js
@@ -16,7 +16,7 @@ function walkCollections (patterns, drizzleData, writePromises = []) {
   if (hasCollection(patterns)) {
     writePromises.push(writePage(patterns.collection.id, patterns.collection,
       drizzleData.options.dest.patterns,
-      drizzleData.options.keys.collections));
+      drizzleData.options.keys.collections.plural));
   }
   for (const patternKey in patterns) {
     if (!isCollection(patterns[patternKey])) {

--- a/src/write/pages.js
+++ b/src/write/pages.js
@@ -16,7 +16,7 @@ function walkPages (pages, drizzleData, writePromises = []) {
   if (isPage(pages)) {
     return writePage(pages.id, pages,
       drizzleData.options.dest.pages,
-      drizzleData.options.keys.pages);
+      drizzleData.options.keys.pages.plural);
   }
   for (var pageKey in pages) {
     writePromises = writePromises.concat(

--- a/test/config.js
+++ b/test/config.js
@@ -82,6 +82,7 @@ var config = {
       }
     },
     dest: {
+      collections: './test/dist/collections',
       pages: './test/dist',
       patterns: './test/dist/patterns'
     },

--- a/test/init.js
+++ b/test/init.js
@@ -59,7 +59,7 @@ describe ('init', () => {
     });
     it('should provide default destination entries', () => {
       return opts.then(options => {
-        expect(options.dest).to.have.keys('pages', 'patterns');
+        expect(options.dest).to.have.keys('pages', 'patterns', 'collections');
         expect(options.dest.patterns).to.equal('./dist/patterns');
       });
     });

--- a/test/parse/index.js
+++ b/test/parse/index.js
@@ -8,7 +8,7 @@ describe ('parse/index (parseAll)', () => {
     var opts = config.init(config.fixtureOpts);
     return opts.then(parseAll).then(allData => {
       expect(allData).to.be.an('object').and.to.have
-        .keys('data', 'pages', 'patterns', 'options', 'templates');
+        .keys('data', 'pages', 'patterns', 'options', 'templates', 'tree');
     });
   });
 });

--- a/test/parse/patterns.js
+++ b/test/parse/patterns.js
@@ -50,7 +50,8 @@ describe ('parse/patterns', () => {
     });
     it ('should define the appropriate properties for each pattern', () => {
       var aPattern = patternData.components.button.collection.items.base;
-      expect(aPattern).to.have.keys('id', 'name', 'data', 'path', 'contents');
+      expect(aPattern).to.have.keys('id', 'name', 'data', 'path', 'contents',
+        'resourceType');
       expect(aPattern).not.to.have.keys('notes', 'links');
       expect(aPattern.data).to.contain.keys('notes', 'links');
     });
@@ -71,7 +72,7 @@ describe ('parse/patterns', () => {
     it ('should add relevant properties to individual pattern objects', () => {
       expect(patternData.collection.items.pink).to.be.an('object');
       expect(patternData.collection.items.pink).to.have.keys(
-        'name', 'id', 'contents', 'path', 'data');
+        'name', 'id', 'contents', 'path', 'data', 'resourceType');
     });
   });
   describe('parsing collections', () => {

--- a/test/parse/tree.js
+++ b/test/parse/tree.js
@@ -1,0 +1,8 @@
+var chai = require('chai');
+var config = require('../config');
+var expect = chai.expect;
+var parseTree = require('../../dist/parse/tree');
+
+describe ('parse/tree', () => {
+  it ('should have tests');
+});

--- a/test/render/index.js
+++ b/test/render/index.js
@@ -15,7 +15,7 @@ describe ('render/index (renderAll)', () => {
   });
   it ('should correctly build composite data object', () => {
     expect(drizzleData).to.be.an('object').and.to.have
-      .keys('data', 'pages', 'patterns', 'options', 'templates');
+      .keys('data', 'pages', 'patterns', 'options', 'templates', 'tree');
     expect(drizzleData.pages).to.contain.keys('components', 'doThis');
     expect(drizzleData.patterns).to.contain.keys('fingers', 'components');
     expect(drizzleData.data).to.contain.keys('data-as-json');

--- a/test/utils/shared.js
+++ b/test/utils/shared.js
@@ -44,6 +44,20 @@ describe ('utils/shared', () => {
       expect(relative).to.be.an('array').and.to.contain('baz', 'ding');
     });
   });
+  describe('resourcePath', () => {
+    it ('should build a resource path from an ID', () => {
+      const pathBuilt = utils.resourcePath('foo.bar.baz.ding.dong');
+      expect(pathBuilt).to.equal('bar/baz/ding/dong.html');
+    });
+    it ('should prefix a dest path', () => {
+      const pathBuilt = utils.resourcePath('foo.bar.baz.ding.dong', 'ding/wow');
+      expect(pathBuilt).to.equal('ding/wow/bar/baz/ding/dong.html');
+    });
+    it ('should be able to tolerate IDs that do not have separators', () => {
+      const pathBuilt = utils.resourcePath('foo');
+      expect(pathBuilt).to.be.ok.and.to.equal('foo.html');
+    });
+  });
   describe('titleCase', () => {
     it ('should correctly title-case a string', () => {
       // @TODO move these into fixtures?

--- a/test/write/collections.js
+++ b/test/write/collections.js
@@ -21,6 +21,8 @@ describe ('write/collections', () => {
     });
     describe ('determining output paths', () => {
       it ('should write out the correct files', () => {
+        // console.log(Object.keys(objectUtils.flattenById(drizzleData.patterns)));
+        // console.log(Object.keys(objectUtils.flattenById(drizzleData.pages)));
         const outPaths = [
           drizzleData.patterns.collection.outputPath,
           drizzleData.patterns.components.collection.outputPath,


### PR DESCRIPTION
I don't consider this feature fully-baked, but there are enough elements of it that I want to get it merged into place for you guys.

The top-level `drizzle` object available in template contexts now has a `tree` property, which has, at present, two sub-objects (`pages` and `collections`). These objects are structured in a more useful way to generate navigation. They are structured like (I'm going to write this in YAML for speed savings):

```
pages:
  items:
    - id: pages.index
      key: index
      path: ./dist/index.html
    - id: pages.another-page
      key: another-page
      path: .dist/another-page.html
  children:
    items: ...
    children: ...
      items: ...
      children: ...
```

You'll note the `path` properties aren't completely useful yet—they're calculated based on the `dest` options passed. We'll want to circle back when we get the `BASE_URL` stuff sorted.

I added some tests and some placeholders for more tests. Trying to get this out there so I can get out of the way sooner than later! The structure might not be quite right, but the foundation is there so you can tweak it as you like.
