### PR TITLE
Fix: Silent Handlebars helper/partial console warnings when used w/ Gulp

### DIFF
--- a/src/init.js
+++ b/src/init.js
@@ -1,7 +1,7 @@
 import deepExtend from 'deep-extend';
 import defaults from './defaults';
 import Promise from 'bluebird';
-
+import Handlebars from 'handlebars';
 import path from 'path';
 
 /**
@@ -31,7 +31,7 @@ function normalizePaths (opts) {
 function init (options = {}, handlebars) {
   const opts = deepExtend({}, defaults, options);
   normalizePaths(opts);
-  opts.handlebars = handlebars || require('handlebars');
+  opts.handlebars = handlebars || Handlebars.create();
   return Promise.resolve(opts);
 }
 


### PR DESCRIPTION
Re: #77 

This change to `init()` indirectly fixes the prompts about duplicate helpers/partials by using a new Handlebars instance each time Drizzle is started (if no `handlebars` instance argument is supplied).