### PR TITLE
Feature: Add data shortcut helper

### DIFF
--- a/src/helpers/data.js
+++ b/src/helpers/data.js
@@ -1,0 +1,25 @@
+/**
+ * @param {String} The path to lookup within drizzle.data
+ * @returns {*} The data located at the supplied path
+ * @example
+ *
+ *    {{#each (data "specimens.headings")}}
+ *      {{this}}
+ *    {{/each}}
+ */
+
+export default function register (options) {
+  const Handlebars = options.handlebars;
+
+  Handlebars.registerHelper('data', (path, context) => {
+    const parts = path.split('.');
+    const root = context.data.root.drizzle.data;
+    const reducer = (prev, curr) => {
+      if (prev.contents) return prev.contents[curr];
+      return prev[curr].contents || prev[curr];
+    };
+    return parts.reduce(reducer, root);
+  });
+
+  return Handlebars;
+}

--- a/src/prepare/helpers.js
+++ b/src/prepare/helpers.js
@@ -5,6 +5,7 @@
 
 import { keyname } from '../utils/shared';
 import { getFiles, isGlob } from '../utils/parse';
+import registerDataHelpers from '../helpers/data';
 import registerPatternHelpers from '../helpers/pattern';
 import handlebarsLayouts from 'handlebars-layouts';
 
@@ -53,6 +54,7 @@ function prepareHelpers (options) {
   return getHelpers(options)
     .then(helpers => {
       options.handlebars = registerPatternHelpers(options);
+      options.handlebars = registerDataHelpers(options);
       for (var helper in helpers) {
         options.handlebars.registerHelper(helper, helpers[helper]);
       }

--- a/test/fixtures/data/people.yaml
+++ b/test/fixtures/data/people.yaml
@@ -1,0 +1,12 @@
+-
+  name: Joe
+  age: 22
+-
+  name: Winston
+  age: 43
+-
+  name: April
+  age: 30
+-
+  name: Myork
+  age: 68

--- a/test/fixtures/pages/usingHelpers.html
+++ b/test/fixtures/pages/usingHelpers.html
@@ -1,0 +1,17 @@
+<!-- Using #with and targeting a specific array index -->
+{{#with (data "another-data.ding.2")}}
+  <output>{{.}}</output>
+{{/with}}
+
+<!-- Using #each to iterate over a data file (object) -->
+{{#each (data "sample-data") as |val key|}}
+  <output>{{key}}: {{val}}</output>
+{{/each}}
+
+<!-- Using #each to iterate over a data file (array of objects) -->
+{{#each (data "people")}}
+  <output>{{name}}: {{age}}</output>
+{{/each}}
+
+<!-- Targeting a specific value -->
+<output>{{data "data-as-json.fortunately"}}</output>

--- a/test/prepare/helpers.js
+++ b/test/prepare/helpers.js
@@ -23,6 +23,9 @@ describe ('prepare/helpers', () => {
       expect(preparedOptions.handlebars.helpers).to.contain.keys(
         'pattern', 'patternSource');
     });
+    it ('should register data helpers', () => {
+      expect(preparedOptions.handlebars.helpers).to.contain.keys('data');
+    });
   });
   describe ('passed helpers', () => {
     it ('should register passed helper', () => {

--- a/test/write/pages.js
+++ b/test/write/pages.js
@@ -47,6 +47,15 @@ describe ('write/pages', () => {
         expect(contents).not.to.contain('Body content should replace this.');
       });
     });
+    it ('should write page files with functioning helpers', () => {
+      return testUtils.fileContents(drizzleData.pages.usingHelpers.outputPath)
+      .then(contents => {
+        expect(contents).to.contain('<output>cat is in the well</output>');
+        expect(contents).to.contain('<output>elfin: small things</output>');
+        expect(contents).to.contain('<output>Winston: 43</output>');
+        expect(contents).to.contain('<output>5</output>');
+      });
+    });
   });
   describe ('write to page destination', () => {
     var alteredData;


### PR DESCRIPTION
This introduces a new Handlebars inline helper that will be available to Drizzle templates.

The purpose of the helper is to provide a more terse method of accessing data. It's simply a shortcut to referencing `{{drizzle.data.filename.contents.key...}}`, allowing access by this method instead:

```{{data "filename.key..."}}```

Some examples:

```hbs
<!-- Using #with and targeting a specific array index -->
{{#with (data "projects.latest.2")}}
  {{title}}
{{/with}}

<!-- Using #each to iterate over a data file (array of objects) -->
{{#each (data "people")}}
  {{name}}: {{age}}
{{/each}}

<!-- Targeting a specific value -->
{{data "articles.0.category"}}
```

/CC @mrgerardorodriguez @tylersticka @nicolemors @saralohr 