### PR TITLE
Feature: page helpers

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "js-beautify": "^1.6.2",
     "js-yaml": "^3.5.3",
     "marked": "^0.3.5",
-    "mkdirp": "^0.5.1"
+    "mkdirp": "^0.5.1",
+    "ramda": "^0.21.0"
   },
   "devDependencies": {
     "babel-cli": "^6.5.1",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "eslint": "^2.5.3",
     "istanbul": "^0.4.2",
     "mocha": "^2.4.5",
+    "prettyjson": "^1.1.3",
     "rimraf": "^2.5.2",
     "sinon": "^1.17.3",
     "sinon-chai": "^2.8.0"

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "js-yaml": "^3.5.3",
     "marked": "^0.3.5",
     "mkdirp": "^0.5.1",
+    "natsort": "^1.0.5",
     "ramda": "^0.21.0"
   },
   "devDependencies": {

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -17,6 +17,7 @@ const defaults = {
     logFn: console.log
   },
   dest          : {
+    root: './dist',
     collections: './dist/patterns',
     pages   : './dist/pages',
     patterns: './dist/patterns'

--- a/src/helpers/page.js
+++ b/src/helpers/page.js
@@ -78,7 +78,9 @@ function menuItem (props, drizzle) {
 export default function register (options) {
   const Handlebars = options.handlebars;
 
-  Handlebars.registerHelper('pages', (path, context) => {
+  Handlebars.registerHelper('pages', (...args) => {
+    const path = R.is(String, args[0]) ? args[0] : '.';
+    const context = args[1] || args[0];
     const drizzle = context.data.root.drizzle;
     const options = context.hash;
     const subset = extractSubset(`pages/${path}`, drizzle);
@@ -101,7 +103,9 @@ export default function register (options) {
     return results;
   });
 
-  Handlebars.registerHelper('page', (path, context) => {
+  Handlebars.registerHelper('page', (...args) => {
+    const path = R.is(String, args[0]) ? args[0] : 'index';
+    const context = args[1] || args[0];
     const drizzle = context.data.root.drizzle;
     const subset = extractSubset(`pages/${path}`, drizzle);
     const result = {};

--- a/src/helpers/page.js
+++ b/src/helpers/page.js
@@ -10,7 +10,7 @@ export default function register (options) {
   Handlebars.registerHelper('pages', (path, context) => {
     const builder = context.data.root.drizzle;
     const pathBits = splitPath(path);
-    const subset = R.path(pathBits, builder.pages);
+    const subset = R.path(pathBits, builder.pages) || builder.pages;
     const isPage = R.propEq('resourceType', 'page');
     const pickProps = R.pick(['id', 'url', 'data', 'key']);
     const options = context.hash;

--- a/src/helpers/page.js
+++ b/src/helpers/page.js
@@ -1,0 +1,43 @@
+import R from 'ramda';
+import {splitPath} from '../utils/object';
+import {resourcePath} from '../utils/shared';
+import {sortByProp} from '../utils/list';
+
+export default function register (options) {
+  const Handlebars = options.handlebars;
+
+  Handlebars.registerHelper('pages', (path, context) => {
+    const builder = context.data.root.drizzle;
+    const pageDest = builder.options.dest.pages;
+    const pathBits = splitPath(path);
+    const subset = R.path(pathBits, builder.pages);
+    const isPage = R.propEq('resourceType', 'page');
+    const pickProps = R.pick(['id', 'url', 'data', 'key']);
+    const options = context.hash;
+    let results = [];
+
+    // Fill results with objects refined from the page subset
+    for (const key in subset) {
+      const page = subset[key];
+      if (isPage(page)) {
+        page.url = resourcePath(page.id, pageDest);
+        page.key = key;
+        results.push(pickProps(page));
+      }
+    }
+
+    // Apply filtering to results
+    if (options.ignore) {
+      results = results.filter(page => page.key !== options.ignore);
+    }
+
+    // Apply sorting to results
+    if (options.sortby) {
+      results = sortByProp(['data', options.sortby], results);
+    }
+
+    return results;
+  });
+
+  return Handlebars;
+}

--- a/src/helpers/page.js
+++ b/src/helpers/page.js
@@ -12,6 +12,15 @@ const pickProps = R.pick(['id', 'url', 'data']);
 
 /**
  * Return an inner object/array from the Drizzle context.
+ *
+ * @param {String} path
+ * The path string (e.g. "foo/bar/baz")
+ *
+ * @param {Object} drizzle
+ * The Drizzle root context.
+ *
+ * @return {Mixed}
+ * Whatever structure exists at the supplied path.
  */
 function extractSubset (path, drizzle) {
   const pathBits = splitPath(path);
@@ -21,6 +30,15 @@ function extractSubset (path, drizzle) {
 
 /**
  * Return a relative base path for .html destinations.
+ *
+ * @param {String} type
+ * The resource type identifier (e.g. "page", "pattern", "collection")
+ *
+ * @param {Object} drizzle
+ * The Drizzle root context.
+ *
+ * @return {String}
+ * The relative base path for the supplied resource type.
  */
 function destRoot (type, drizzle) {
   // TODO: this is unfortunate, and due to difficulty using defaults.keys
@@ -38,6 +56,16 @@ function destRoot (type, drizzle) {
 
 /**
  * Return a refined object (page, pattern, etc.) representing a menu item.
+ *
+ * @param {Object} props
+ * The "raw" object representation of a menu item.
+ *
+ * @param {Object} drizzle
+ * The Drizzle root context.
+ *
+ * @return {Object}
+ * The "refined" object representation of a menu item (with fewer properties
+ * and a new `url` property).
  */
 function menuItem (props, drizzle) {
   props.url = resourcePath(

--- a/src/helpers/page.js
+++ b/src/helpers/page.js
@@ -4,34 +4,45 @@ import {splitPath} from '../utils/object';
 import {resourcePath} from '../utils/shared';
 import {sortByProp} from '../utils/list';
 
+function extractPages (path, drizzle) {
+  const pages = drizzle.pages;
+  const pathBits = splitPath(path);
+  const isPage = R.propEq('resourceType', 'page');
+  const pickProps = R.pick(['id', 'url', 'data', 'key', 'path']);
+  const results = [];
+  let subset = R.path(pathBits, pages) || Object.assign({}, pages);
+
+  // TODO: https://github.com/cloudfour/drizzle/issues/43
+  const pageDest = relativePath(
+    drizzle.options.dest.root,
+    drizzle.options.dest.pages
+  );
+
+  // If path pointed to a single page, wrap it up
+  if (isPage(subset)) {
+    subset = Object.assign({}, {[path]: subset});
+  }
+
+  // Fill results with objects refined from the page subset
+  for (const key in subset) {
+    const page = subset[key];
+    if (isPage(page)) {
+      page.url = resourcePath(page.id, pageDest);
+      page.key = key;
+      page.path = path;
+      results.push(pickProps(page));
+    }
+  }
+
+  return results;
+}
+
 export default function register (options) {
   const Handlebars = options.handlebars;
 
   Handlebars.registerHelper('pages', (path, context) => {
-    const builder = context.data.root.drizzle;
-    const pathBits = splitPath(path);
-    const subset = R.path(pathBits, builder.pages) || builder.pages;
-    const isPage = R.propEq('resourceType', 'page');
-    const pickProps = R.pick(['id', 'url', 'data', 'key']);
     const options = context.hash;
-
-    // TODO: https://github.com/cloudfour/drizzle/issues/43
-    const pageDest = relativePath(
-      builder.options.dest.root,
-      builder.options.dest.pages
-    );
-
-    let results = [];
-
-    // Fill results with objects refined from the page subset
-    for (const key in subset) {
-      const page = subset[key];
-      if (isPage(page)) {
-        page.url = resourcePath(page.id, pageDest);
-        page.key = key;
-        results.push(pickProps(page));
-      }
-    }
+    let results = extractPages(path, context.data.root.drizzle);
 
     // Apply filtering to results
     if (options.ignore) {
@@ -44,6 +55,12 @@ export default function register (options) {
     }
 
     return results;
+  });
+
+  Handlebars.registerHelper('page', (path, context) => {
+    const pages = extractPages(path, context.data.root.drizzle);
+    const result = pages.find(page => page.path === path);
+    return result;
   });
 
   return Handlebars;

--- a/src/helpers/page.js
+++ b/src/helpers/page.js
@@ -1,4 +1,5 @@
 import R from 'ramda';
+import {relative as relativePath} from 'path';
 import {splitPath} from '../utils/object';
 import {resourcePath} from '../utils/shared';
 import {sortByProp} from '../utils/list';
@@ -8,12 +9,18 @@ export default function register (options) {
 
   Handlebars.registerHelper('pages', (path, context) => {
     const builder = context.data.root.drizzle;
-    const pageDest = builder.options.dest.pages;
     const pathBits = splitPath(path);
     const subset = R.path(pathBits, builder.pages);
     const isPage = R.propEq('resourceType', 'page');
     const pickProps = R.pick(['id', 'url', 'data', 'key']);
     const options = context.hash;
+
+    // TODO: https://github.com/cloudfour/drizzle/issues/43
+    const pageDest = relativePath(
+      builder.options.dest.root,
+      builder.options.dest.pages
+    );
+
     let results = [];
 
     // Fill results with objects refined from the page subset

--- a/src/prepare/helpers.js
+++ b/src/prepare/helpers.js
@@ -6,6 +6,7 @@
 import { keyname } from '../utils/shared';
 import { getFiles, isGlob } from '../utils/parse';
 import registerDataHelpers from '../helpers/data';
+import registerPageHelpers from '../helpers/page';
 import registerPatternHelpers from '../helpers/pattern';
 import handlebarsLayouts from 'handlebars-layouts';
 
@@ -55,6 +56,7 @@ function prepareHelpers (options) {
     .then(helpers => {
       options.handlebars = registerPatternHelpers(options);
       options.handlebars = registerDataHelpers(options);
+      options.handlebars = registerPageHelpers(options);
       for (var helper in helpers) {
         options.handlebars.registerHelper(helper, helpers[helper]);
       }

--- a/src/utils/list.js
+++ b/src/utils/list.js
@@ -1,0 +1,31 @@
+import R from 'ramda';
+
+/**
+ * Sort an array of objects by property.
+ *
+ * @param {String|Array} prop
+ * A property to sort by. If passed as an array, it
+ * will be treated as a deep property path.
+ *
+ * @param {Array} list
+ * An array of objects to sort.
+ *
+ * @return {Array}
+ * A sorted copy of the passed array.
+ *
+ * @example
+ * sortByProp('order', items);
+ * // [{order: 1}, {order: 2}]
+ */
+function sortByProp (prop, list) {
+  const get = R.is(Array, prop) ? R.path : R.prop;
+  return R.sort((elA, elB) => {
+    const a = get(prop, elA);
+    const b = get(prop, elB);
+    return (a || b) ? (!a ? 1 : !b ? -1 : a.localeCompare(b)) : 0;
+  }, list);
+}
+
+export {
+  sortByProp
+};

--- a/src/utils/list.js
+++ b/src/utils/list.js
@@ -19,6 +19,10 @@ const sortObjects = natsort();
  * @example
  * sortByProp('order', items);
  * // [{order: 1}, {order: 2}]
+ *
+ * @example
+ * sortByProp(['data', 'title'], items);
+ * // [{data: {title: 'a'}}, {data: {title: 'b'}}]
  */
 function sortByProp (prop, list) {
   const get = R.is(Array, prop) ? R.path : R.prop;

--- a/src/utils/list.js
+++ b/src/utils/list.js
@@ -1,4 +1,7 @@
 import R from 'ramda';
+import natsort from 'natsort';
+
+const sortObjects = natsort();
 
 /**
  * Sort an array of objects by property.
@@ -22,7 +25,7 @@ function sortByProp (prop, list) {
   return R.sort((elA, elB) => {
     const a = get(prop, elA);
     const b = get(prop, elB);
-    return (a || b) ? (!a ? 1 : !b ? -1 : a.localeCompare(b)) : 0;
+    return sortObjects(a, b);
   }, list);
 }
 

--- a/src/utils/object.js
+++ b/src/utils/object.js
@@ -125,11 +125,31 @@ function resourceKey (resourceFile) {
   return keyname(resourceFile.path);
 }
 
+/**
+ * Split a path string delimited by "." or "/".
+ *
+ * @param {String} path
+ * A path string to split.
+ *
+ * @return {Array}
+ * An array of path segments.
+ *
+ * @example
+ * splitPath('a/b/c/1.2.3');
+ * // ['a', 'b', 'c', '1', '2', '3']
+ */
+function splitPath (path) {
+  const delim = /[\.\/]/;
+  const result = path.split(delim);
+  return result;
+}
+
 export { deepCollection, // object
          deepObj, // object
          deepPattern, // object
          flattenById,
          keyname, // object
          resourceId, //object
-         resourceKey // object
+         resourceKey, // object
+         splitPath
        };

--- a/src/utils/object.js
+++ b/src/utils/object.js
@@ -1,5 +1,5 @@
 import { idKeys, keyname, relativePathArray } from './shared';
-
+import R from 'ramda';
 import DrizzleError from './error';
 
 /**
@@ -140,7 +140,7 @@ function resourceKey (resourceFile) {
  */
 function splitPath (path) {
   const delim = /[\.\/]/;
-  const result = path.split(delim);
+  const result = R.pipe(R.split(delim), R.without(''))(path);
   return result;
 }
 

--- a/src/utils/shared.js
+++ b/src/utils/shared.js
@@ -1,4 +1,5 @@
 import path from 'path';
+import R from 'ramda';
 
 /**
  * Split a string on a common separator.
@@ -8,6 +9,7 @@ import path from 'path';
 function idKeys (idString) {
   return idString.split('.');
 }
+
 /**
  * Utility function to process strings to make them key-like (for properties).
  * Previously this stripped prefixed numbers, etc., but for now it is
@@ -75,9 +77,21 @@ function titleCase (str) {
     .replace(/\w\S*/g, word => word.charAt(0).toUpperCase() + word.substr(1));
 }
 
+/**
+ * Resource type logic.
+ */
+const isType = R.propEq('resourceType');
+const isPage = isType('page');
+const isPattern = isType('pattern');
+const isCollection = isType('collection');
+
 export { idKeys,
          keyname,
          relativePathArray,
          resourcePath,
-         titleCase
+         titleCase,
+         isType,
+         isPage,
+         isPattern,
+         isCollection
        };

--- a/test/config.js
+++ b/test/config.js
@@ -82,6 +82,7 @@ var config = {
       }
     },
     dest: {
+      root: './test/dist',
       collections: './test/dist/collections',
       pages: './test/dist',
       patterns: './test/dist/patterns'

--- a/test/fixtures/pages/follow-me/down/apage.md
+++ b/test/fixtures/pages/follow-me/down/apage.md
@@ -1,6 +1,7 @@
 ---
 customHeader: foobar
 layout: page
+alias: grape
 ---
 
 * Thing

--- a/test/fixtures/pages/follow-me/down/orthree.md
+++ b/test/fixtures/pages/follow-me/down/orthree.md
@@ -1,6 +1,8 @@
 ---
 customHeader: foobar
 layout: page
+order: 1
+alias: watermelon
 ---
 
 * Thing

--- a/test/fixtures/pages/follow-me/down/ortwo.md
+++ b/test/fixtures/pages/follow-me/down/ortwo.md
@@ -1,6 +1,7 @@
 ---
 customHeader: foobar
 layout: page
+alias: apple
 ---
 
 * Thing

--- a/test/fixtures/pages/usingPageHelpers.html
+++ b/test/fixtures/pages/usingPageHelpers.html
@@ -13,3 +13,7 @@
 {{#with (pages "follow-me/down" sortby="alias")}}
   <output>alias: {{this.[0].data.alias}}</output>
 {{/with}}
+
+{{#with (page "nerkle")}}
+  <output>page: {{id}}</output>
+{{/with}}

--- a/test/fixtures/pages/usingPageHelpers.html
+++ b/test/fixtures/pages/usingPageHelpers.html
@@ -1,0 +1,11 @@
+{{#each (pages "follow-me/down")}}
+  <output>{{key}}: {{url}}</output>
+{{/each}}
+
+{{#with (pages "follow-me/down" sortby="order")}}
+  <output>order: {{this.[0].data.order}}</output>
+{{/with}}
+
+{{#with (pages "follow-me/down" sortby="alias")}}
+  <output>alias: {{this.[0].data.alias}}</output>
+{{/with}}

--- a/test/fixtures/pages/usingPageHelpers.html
+++ b/test/fixtures/pages/usingPageHelpers.html
@@ -1,9 +1,5 @@
-{{#each (pages "follow-me/down")}}
-  <output>{{key}}: {{url}}</output>
-{{/each}}
-
 {{#with (pages ".")}}
-  <output>default: {{this.[0].key}}</output>
+  <output>default: {{this.[0].url}}</output>
 {{/with}}
 
 {{#with (pages "follow-me/down" sortby="order")}}

--- a/test/fixtures/pages/usingPageHelpers.html
+++ b/test/fixtures/pages/usingPageHelpers.html
@@ -2,6 +2,10 @@
   <output>{{key}}: {{url}}</output>
 {{/each}}
 
+{{#with (pages ".")}}
+  <output>default: {{this.[0].key}}</output>
+{{/with}}
+
 {{#with (pages "follow-me/down" sortby="order")}}
   <output>order: {{this.[0].data.order}}</output>
 {{/with}}

--- a/test/fixtures/pages/usingPageHelpers.html
+++ b/test/fixtures/pages/usingPageHelpers.html
@@ -1,8 +1,8 @@
-{{#with (pages ".")}}
+{{#with (pages)}}
   <output>default: {{this.[0].url}}</output>
 {{/with}}
 
-{{#with (pages "follow-me/down" sortby="order")}}
+{{#with (pages "follow-me.down" sortby="order")}}
   <output>order: {{this.[0].data.order}}</output>
 {{/with}}
 

--- a/test/init.js
+++ b/test/init.js
@@ -59,7 +59,7 @@ describe ('init', () => {
     });
     it('should provide default destination entries', () => {
       return opts.then(options => {
-        expect(options.dest).to.have.keys('pages', 'patterns', 'collections');
+        expect(options.dest).to.have.keys('root', 'pages', 'patterns', 'collections');
         expect(options.dest.patterns).to.equal('./dist/patterns');
       });
     });

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -2,7 +2,8 @@ const fs = require('fs');
 const Promise = require('bluebird');
 const readFile = Promise.promisify(fs.readFile);
 const stat     = Promise.promisify(fs.stat);
-const sinon    = require('sinon');
+const prettyjson = require('prettyjson');
+
 
 function areFiles (paths) {
   return Promise.all(paths.map(isFile)).then(results => {
@@ -23,8 +24,16 @@ function fileContents (path) {
   return readFile(path, 'utf-8');
 }
 
+/**
+ * Console log as nicely formatted YAML.
+ */
+function log (data) {
+  console.log(prettyjson.render(data, {indent: 2}));
+}
+
 module.exports = {
   areFiles: areFiles,
   fileContents: fileContents,
-  isFile: isFile
+  isFile: isFile,
+  log: log
 };

--- a/test/write/pages.js
+++ b/test/write/pages.js
@@ -8,7 +8,7 @@ var writePages = require('../../dist/write/pages');
 var testUtils = require('../test-utils');
 var objectUtils = require('../../dist/utils/object');
 
-describe.only ('write/pages', () => {
+describe ('write/pages', () => {
   var drizzleData;
   describe ('write out page files', () => {
     before (() => {

--- a/test/write/pages.js
+++ b/test/write/pages.js
@@ -8,7 +8,7 @@ var writePages = require('../../dist/write/pages');
 var testUtils = require('../test-utils');
 var objectUtils = require('../../dist/utils/object');
 
-describe ('write/pages', () => {
+describe.only ('write/pages', () => {
   var drizzleData;
   describe ('write out page files', () => {
     before (() => {
@@ -47,13 +47,21 @@ describe ('write/pages', () => {
         expect(contents).not.to.contain('Body content should replace this.');
       });
     });
-    it ('should write page files with functioning helpers', () => {
+    it ('should write page files with functioning {{data}} helpers', () => {
       return testUtils.fileContents(drizzleData.pages.usingHelpers.outputPath)
       .then(contents => {
         expect(contents).to.contain('<output>cat is in the well</output>');
         expect(contents).to.contain('<output>elfin: small things</output>');
         expect(contents).to.contain('<output>Winston: 43</output>');
         expect(contents).to.contain('<output>5</output>');
+      });
+    });
+    it ('should write page files with functioning {{pages}} helpers', () => {
+      return testUtils.fileContents(drizzleData.pages.usingPageHelpers.outputPath)
+      .then(contents => {
+        expect(contents).to.contain('<output>apage:');
+        expect(contents).to.contain('<output>order: 1</output>');
+        expect(contents).to.contain('<output>alias: apple</output>');
       });
     });
   });

--- a/test/write/pages.js
+++ b/test/write/pages.js
@@ -60,6 +60,7 @@ describe ('write/pages', () => {
       return testUtils.fileContents(drizzleData.pages.usingPageHelpers.outputPath)
       .then(contents => {
         expect(contents).to.contain('<output>apage:');
+        expect(contents).to.contain('<output>default: 04-sandbox</output>');
         expect(contents).to.contain('<output>order: 1</output>');
         expect(contents).to.contain('<output>alias: apple</output>');
       });

--- a/test/write/pages.js
+++ b/test/write/pages.js
@@ -59,8 +59,7 @@ describe ('write/pages', () => {
     it ('should write page files with functioning {{pages}} helpers', () => {
       return testUtils.fileContents(drizzleData.pages.usingPageHelpers.outputPath)
       .then(contents => {
-        expect(contents).to.contain('<output>apage:');
-        expect(contents).to.contain('<output>default: 04-sandbox</output>');
+        expect(contents).to.contain('<output>default: 04-sandbox.html</output>');
         expect(contents).to.contain('<output>order: 1</output>');
         expect(contents).to.contain('<output>alias: apple</output>');
         expect(contents).to.contain('<output>page: pages.nerkle</output>');

--- a/test/write/pages.js
+++ b/test/write/pages.js
@@ -63,6 +63,7 @@ describe ('write/pages', () => {
         expect(contents).to.contain('<output>default: 04-sandbox</output>');
         expect(contents).to.contain('<output>order: 1</output>');
         expect(contents).to.contain('<output>alias: apple</output>');
+        expect(contents).to.contain('<output>page: pages.nerkle</output>');
       });
     });
   });


### PR DESCRIPTION
Re: https://github.com/cloudfour/drizzle/issues/23, #83 

### Overview 

This adds two new Handlebars helpers:

- `{{page}}`
- `{{pages}}`

They both return a data context (object or array), and are intended to be combined with `{{#with}}` and `{{#each}}`. The purpose of them is to provide a more convenient/flexible way to generate a listing of menu items (including `url` values).

### `{{pages}}` example

```hbs
{{#each (pages ".")}}
  <li>
    <a class="drizzle-Nav-item" href="{{baseurl}}/{{url}}">
      {{data.title}}
    </a>
  </li>
{{/each}}
```

```hbs
{{#each (pages "demos/examples" sortby="order" ignore="index")}}
  <li>
    <a class="drizzle-Nav-item" href="{{baseurl}}/{{url}}">
      {{data.title}}
    </a>
  </li>
{{/each}}
```

### `{{page}}` example

```hbs
{{#with (page "demos/index")}}
  <a class="drizzle-Nav-item" href="{{baseurl}}/{{url}}">
    {{data.title}}
  </a>
{{/with}}
```

They both require a _path_ value, which maps to the directory structure. Paths can be delimited by dots or slashes.

For example, to iterate over files at `src/pages/foo/bar/baz`, the path would be:

```
pages "foo/bar/baz"
pages "foo.bar.baz"
``` 

The `pages` helper comes with optional hash properties:

- `sortby` will sort the results by a property within the `data` front-matter.
- `ignore` will omit pages with a matching base file name. 

/CC @tylersticka @nicolemors @saralohr 
