### PR TITLE
Feature: Change `body` block to `main`

### DIFF
--- a/src/render/pages.js
+++ b/src/render/pages.js
@@ -25,7 +25,7 @@ function wrapWithLayout (page, drizzleData) {
     `{{\\s*#extend\\s*[\'\"]${layout}[\'\"].*}}`)
     .test(page.contents);
   const wrapped = (alreadyWrapped) ? page.contents : `  {{#extend '${layout}' }}
-    {{#content 'body'}}${page.contents}{{/content}}
+    {{#content 'main'}}${page.contents}{{/content}}
   {{/extend}}`;
   return wrapped;
 }

--- a/test/fixtures/templates/collection.html
+++ b/test/fixtures/templates/collection.html
@@ -1,5 +1,5 @@
 {{#extend "default"}}
-  {{#content "body"}}
+  {{#content "main"}}
     <h2>{{name}}</h2>
     {{#each patterns}}
       {{#pattern id @root}}{{/pattern}}

--- a/test/fixtures/templates/default.html
+++ b/test/fixtures/templates/default.html
@@ -9,7 +9,7 @@
 </head>
 
 <body>
-  {{#block "body"}}
+  {{#block "main"}}
     Body content should replace this.
   {{/block}}
 </body>

--- a/test/fixtures/templates/page.html
+++ b/test/fixtures/templates/page.html
@@ -11,7 +11,7 @@
 <body>
   <h1>This is the Page Layout</h1>
   <h2>{{customHeader}}</h2>
-  {{#block "body"}}
+  {{#block "main"}}
     Body content should replace this.
   {{/block}}
 </body>


### PR DESCRIPTION
## Overview

This PR is the first bit of work to address https://github.com/cloudfour/drizzle/issues/53. The goal is to use `main` as the main content block as opposed to `body`. 

cc: @erikjung @tylersticka 