### PR TITLE
Feature: add collections helper

### DIFF
--- a/src/helpers/page.js
+++ b/src/helpers/page.js
@@ -96,7 +96,6 @@ export default function register (options) {
     }
 
     if (options.sortby) {
-      // TODO: do we want to access via "data.foo" or just "foo"
       results = sortByProp(['data', options.sortby], results);
     }
 

--- a/src/parse/tree.js
+++ b/src/parse/tree.js
@@ -3,8 +3,6 @@
  * @module parse/tree
  */
 
-import { resourcePath } from '../utils/shared';
-
 /**
 return {
   data      : allData[0],
@@ -15,22 +13,22 @@ return {
 };
 **/
 
-function walkResources (resources, options, resourceType, resourceTree = {}) {
+function walkResources (
+  resources,
+  options,
+  resourceType,
+  resourceTree = []
+) {
   for (var resourceKey in resources) {
-    if (resources[resourceKey].resourceType &&
-      resources[resourceKey].resourceType === resourceType.singular) {
-      resourceTree.items = resourceTree.items || [];
-      resourceTree.items.push({
-        id: resources[resourceKey].id,
-        key: resourceKey,
-        path: resourcePath(resources[resourceKey].id,
-          options.dest[resourceType.plural], options)
-      });
+    const item = resources[resourceKey];
+    if (item.resourceType && item.resourceType === resourceType.singular) {
+      resourceTree.push(item);
     } else {
-      resourceTree.children = resourceTree.children || [];
-      resourceTree.children.push(
-        walkResources(resources[resourceKey], options,
-          resourceType, resourceTree[resourceKey])
+      walkResources(
+        item,
+        options,
+        resourceType,
+        resourceTree
       );
     }
   }
@@ -44,9 +42,16 @@ function parseTree (allData, options) {
     patterns : allData[2],
     templates: allData[3],
     tree: {
-      pages: walkResources(allData[1], options, options.keys.pages),
+      pages: walkResources(
+        allData[1],
+        options,
+        options.keys.pages
+      ),
       collections: walkResources(
-        allData[2], options, options.keys.collections)
+        allData[2],
+        options,
+        options.keys.collections
+      )
     },
     options  : options
   };

--- a/src/utils/object.js
+++ b/src/utils/object.js
@@ -1,6 +1,7 @@
-import { idKeys, keyname, relativePathArray } from './shared';
+import {idKeys, keyname, relativePathArray} from './shared';
 import R from 'ramda';
 import DrizzleError from './error';
+import {join, relative} from 'path';
 
 /**
  * Return a reference to the deeply-nested object indicated by the items
@@ -144,6 +145,42 @@ function splitPath (path) {
   return result;
 }
 
+/**
+ * Normalize a sloppy (or dot-separated) path into a "valid" path.
+ *
+ * @param {String} path
+ * A raw input path string.
+ *
+ * @return {String}
+ * A normalized path string.
+ *
+ * @example
+ * normalizePath('foo/bar//baz.bang.1./');
+ * // 'foo/bar/baz/bang/1'
+ */
+function normalizePath (path) {
+  return join(...splitPath(path));
+}
+
+/**
+ * Check if one path is a direct child of another.
+ *
+ * @param {String} pathA
+ * @param {String} pathB
+ * @return {Boolean}
+ *
+ * @example
+ * isPathChild('components/button', 'components');
+ * // true
+ */
+function isPathChild (pathA, pathB) {
+  const relPath = relative(
+    normalizePath(pathA),
+    normalizePath(pathB)
+  );
+  return relPath === '..';
+}
+
 export { deepCollection, // object
          deepObj, // object
          deepPattern, // object
@@ -151,5 +188,7 @@ export { deepCollection, // object
          keyname, // object
          resourceId, //object
          resourceKey, // object
-         splitPath
+         splitPath,
+         normalizePath,
+         isPathChild
        };

--- a/test/config.js
+++ b/test/config.js
@@ -83,7 +83,7 @@ var config = {
     },
     dest: {
       root: './test/dist',
-      collections: './test/dist/collections',
+      collections: './test/dist/patterns',
       pages: './test/dist',
       patterns: './test/dist/patterns'
     },

--- a/test/fixtures/pages/helpers-demo-collections.hbs
+++ b/test/fixtures/pages/helpers-demo-collections.hbs
@@ -1,0 +1,21 @@
+{{#* inline "collection-item"}}
+	<output test-collection-index="{{@index}}" test-collection-id="{{id}}">
+    {{url}}
+    {{name}}
+  </output>
+{{/inline}}
+
+<!-- Iterating over collections -->
+{{#each (collections) as |collection|}}
+	{{> collection-item collection}}
+{{/each}}
+
+<!-- Iterating over collections: "components" -->
+{{#each (collections "components") as |collection|}}
+	{{> collection-item collection}}
+{{/each}}
+
+<!-- Iterating over collections: "typography" -->
+{{#each (collections "typography") as |collection|}}
+	{{> collection-item collection}}
+{{/each}}

--- a/test/write/pages.js
+++ b/test/write/pages.js
@@ -47,7 +47,7 @@ describe ('write/pages', () => {
         expect(contents).not.to.contain('Body content should replace this.');
       });
     });
-    it ('should write page files with functioning {{data}} helpers', () => {
+    it ('should write page files with functioning {{data}} helper', () => {
       return testUtils.fileContents(drizzleData.pages.usingHelpers.outputPath)
       .then(contents => {
         expect(contents).to.contain('<output>cat is in the well</output>');
@@ -56,13 +56,27 @@ describe ('write/pages', () => {
         expect(contents).to.contain('<output>5</output>');
       });
     });
-    it ('should write page files with functioning {{pages}} helpers', () => {
+    it ('should write page files with functioning {{pages}} helper', () => {
       return testUtils.fileContents(drizzleData.pages.usingPageHelpers.outputPath)
       .then(contents => {
         expect(contents).to.contain('<output>default: 04-sandbox.html</output>');
         expect(contents).to.contain('<output>order: 1</output>');
         expect(contents).to.contain('<output>alias: apple</output>');
         expect(contents).to.contain('<output>page: pages.nerkle</output>');
+      });
+    });
+    it ('should write page files with functioning {{collections}} helper', () => {
+      return testUtils.fileContents(drizzleData.pages['helpers-demo-collections'].outputPath)
+      .then(contents => {
+        expect(contents).to.contain(
+          '<output test-collection-index="0" test-collection-id="collections.components">'
+        );
+        expect(contents).to.contain(
+          '<output test-collection-index="0" test-collection-id="collections.components.button">'
+        );
+        expect(contents).to.contain(
+          '<output test-collection-index="0" test-collection-id="collections.typography.headings">'
+        );
       });
     });
   });


### PR DESCRIPTION
Re: #88, #83, https://github.com/cloudfour/drizzle/issues/23

This adds a `{{collections}}` helper to assist in iterating over collections of patterns.

Like the `{{pages}}` and `{{data}}` helpers, this also accepts a path argument.

### Usage examples

```hbs
{{#each (collections)}}
  <li>
    <a class="drizzle-Nav-item" href="{{baseurl}}/{{url}}">
      {{name}}
    </a>
  </li>
{{/each}}

{{#each (collections "components")}}
  <li>
    <a class="drizzle-Nav-item" href="{{baseurl}}/{{url}}">
      {{name}}
    </a>
  </li>
{{/each}}

{{#each (collections "typography")}}
  <li>
    <a class="drizzle-Nav-item" href="{{baseurl}}/{{url}}">
      {{name}}
    </a>
  </li>
{{/each}}
```

### Is there any sorting or ignoring?

Not at this time. The underlying structure for collections is different than that for pages, and doesn't have the same access to front matter at the directory level.

### Why `{{name}}` instead of `{{data.title}}`?

Related to the above answer, the collection names are completely derived from the directories.

/CC @tylersticka @saralohr @nicolemors 