### PR TITLE
Feature: Attach `baseurl` property to template context

### DIFF
--- a/src/utils/context.js
+++ b/src/utils/context.js
@@ -3,6 +3,25 @@ import { resourcePath } from './shared';
 import path from 'path';
 import { pathSatisfies, is } from 'ramda';
 
+/**
+ * This will return a relative URL prefix for a given resource (anything being
+ * output to an HTML file).
+ *
+ * The purpose of this to value is to be assigned to the `{{baseurl}}` template
+ * context property, for use in relative URLs within the HTML.
+ *
+ * This relative path is determined by the path-based ID of the resource (e.g.
+ * patterns.components.button) and the `dest` configration settings for the
+ * `resourceType` of the supplied resource (e.g. 'page', 'pattern').
+ *
+ * @param {Object} resource
+ * @param {Object} drizzleData
+ * @return {String}
+ *
+ * @example
+ * getBaseUrl(somePageResource, drizzleData);
+ * // '../..'
+ */
 function getBaseUrl (resource, drizzleData) {
   const options = drizzleData.options;
   const destRoot = options.dest.root;

--- a/src/utils/context.js
+++ b/src/utils/context.js
@@ -1,6 +1,7 @@
 import { deepCollection } from './object'; // TODO NOPE
 import { resourcePath } from './shared';
 import path from 'path';
+import { pathSatisfies, is } from 'ramda';
 
 function getBaseUrl (resource, drizzleData) {
   const options = drizzleData.options;
@@ -23,7 +24,7 @@ function resourceContext (resource, drizzleData) {
   const context = Object.assign({}, resource);
   context.drizzle = drizzleData;
 
-  if (drizzleData.options.dest) {
+  if (pathSatisfies(is(String), ['dest', 'root'], drizzleData.options)) {
     context.baseurl = getBaseUrl(resource, drizzleData);
   }
 

--- a/src/utils/context.js
+++ b/src/utils/context.js
@@ -1,8 +1,32 @@
 import { deepCollection } from './object'; // TODO NOPE
+import { resourcePath } from './shared';
+import path from 'path';
+
+function getBaseUrl (resource, drizzleData) {
+  const options = drizzleData.options;
+  const destRoot = options.dest.root;
+  const destResource = options.dest[
+    Object.keys(options.keys).find(
+      key => options.keys[key].singular === resource.resourceType
+    )
+  ];
+
+  const baseurl = path.relative(
+    path.dirname(resourcePath(resource.id, destResource)),
+    destRoot
+  );
+
+  return baseurl === '' ? `.${baseurl}` : baseurl;
+}
 
 function resourceContext (resource, drizzleData) {
   const context = Object.assign({}, resource);
   context.drizzle = drizzleData;
+
+  if (drizzleData.options.dest) {
+    context.baseurl = getBaseUrl(resource, drizzleData);
+  }
+
   if (typeof resource.data === 'object') {
     Object.keys(resource.data).map(dataKey =>
       context[dataKey] = resource.data[dataKey]);


### PR DESCRIPTION
Re: #63, https://github.com/cloudfour/drizzle/issues/43

This change makes the `{{baseurl}}` template property have a value.

The value will be different depending on the location of each page, and will always be a relative path string pointing to the destination root directory (e.g. `dist`).

For example:

```hbs
<!-- src/pages/index.hbs -->
<script src="{{baseurl}}/main.js">
```

```html
<!-- dist/index.html -->
<script src="./main.js">
```

```hbs
<!-- src/pages/sandbox/demos/navigation.hbs -->
<script src="{{baseurl}}/main.js">
```

```html
<!-- dist/sandbox/demos/navigation.html -->
<script src="../../main.js">
```

This will allow the static HTML output to be viewed using the `file://` protocol without needing any server:

![screen shot 2016-05-19 at 3 48 26 pm](https://cloud.githubusercontent.com/assets/61204/15412013/2a7d8800-1dd9-11e6-9c06-50b3e5b64f98.png)

/CC @tylersticka @saralohr @nicolemors @aileenjeffries 