### PR TITLE
Feature: Add `{{ns}}` helper and tests

### DIFF
--- a/src/helpers/string.js
+++ b/src/helpers/string.js
@@ -1,0 +1,54 @@
+import {
+  concat,
+  join,
+  map,
+  pipe,
+  split,
+  trim
+} from 'ramda';
+
+/**
+ * Prefix every word in string with a namespace.
+ *
+ * The prefix (default: `ns-`) can be supplied as an option globally, or as an
+ * argument when using the helper. This is intended to be used with HTML
+ * attribute values, such as `[class]`.
+ *
+ * @example
+ * <div class="{{ns "One Two"}}">
+ * {{!
+ *   <div class="ns-One ns-Two">
+ * }}
+ *
+ * @example
+ * <div class="{{ns "Component u-util" prefix="foo-"}}">
+ * {{!
+ *   <div class="foo-Component foo-u-util">
+ * }}
+ */
+export function ns (Handlebars, options) {
+  const defaults = {prefix: 'ns-'};
+
+  return (str, context) => {
+    const {prefix} = Object.assign(
+      defaults,
+      options,
+      context.hash
+    );
+
+    const transform = pipe(
+      trim,
+      split(/[\s\t\n\r]+/gm),
+      map(concat(prefix)),
+      join(' ')
+    );
+
+    const result = transform(str.toString());
+
+    return new Handlebars.SafeString(result);
+  };
+}
+
+export default {
+  ns
+};

--- a/src/prepare/helpers.js
+++ b/src/prepare/helpers.js
@@ -8,6 +8,7 @@ import { getFiles, isGlob } from '../utils/parse';
 import registerDataHelpers from '../helpers/data';
 import registerPageHelpers from '../helpers/page';
 import registerPatternHelpers from '../helpers/pattern';
+import stringHelpers from '../helpers/string';
 import handlebarsLayouts from 'handlebars-layouts';
 
 import DrizzleError from '../utils/error';
@@ -54,9 +55,14 @@ function prepareHelpers (options) {
   options.handlebars.registerHelper(handlebarsLayouts(options.handlebars));
   return getHelpers(options)
     .then(helpers => {
-      options.handlebars = registerPatternHelpers(options);
-      options.handlebars = registerDataHelpers(options);
-      options.handlebars = registerPageHelpers(options);
+      registerPatternHelpers(options);
+      registerDataHelpers(options);
+      registerPageHelpers(options);
+
+      options.handlebars.registerHelper(
+        'ns', stringHelpers.ns(options.handlebars, {prefix: 'drizzle-'})
+      );
+
       for (var helper in helpers) {
         options.handlebars.registerHelper(helper, helpers[helper]);
       }

--- a/test/fixtures/pages/helpers-demo-string.hbs
+++ b/test/fixtures/pages/helpers-demo-string.hbs
@@ -1,3 +1,7 @@
+---
+someClass: cheese
+---
+
 <!-- ns helper with defaults -->
 <output test-ns-default="{{ns 'one two three'}}"></output>
 
@@ -11,3 +15,6 @@
           nine
               ten
   '}}"></output>
+
+  <!-- ns helper with front-matter property -->
+  <output test-ns-yfm="{{ns 'ham'}} {{ns someClass}}"></output>

--- a/test/fixtures/pages/helpers-demo-string.hbs
+++ b/test/fixtures/pages/helpers-demo-string.hbs
@@ -1,0 +1,13 @@
+<!-- ns helper with defaults -->
+<output test-ns-default="{{ns 'one two three'}}"></output>
+
+<!-- ns helper with prefix option -->
+<output test-ns-prefix="{{ns 'four five six' prefix='foo-'}}"></output>
+
+<!-- ns helper with whitespace -->
+<output test-ns-whitespace="{{ns '
+  seven
+      eight
+          nine
+              ten
+  '}}"></output>

--- a/test/write/pages.js
+++ b/test/write/pages.js
@@ -91,6 +91,9 @@ describe ('write/pages', () => {
         expect(contents).to.contain(
           '<output test-ns-whitespace="drizzle-seven drizzle-eight drizzle-nine drizzle-ten">'
         );
+        expect(contents).to.contain(
+          '<output test-ns-yfm="drizzle-ham drizzle-cheese">'
+        );
       });
     });
   });

--- a/test/write/pages.js
+++ b/test/write/pages.js
@@ -79,6 +79,20 @@ describe ('write/pages', () => {
         );
       });
     });
+    it ('should write page files with functioning {{ns}} helper', () => {
+      return testUtils.fileContents(drizzleData.pages['helpers-demo-string'].outputPath)
+      .then(contents => {
+        expect(contents).to.contain(
+          '<output test-ns-default="drizzle-one drizzle-two drizzle-three">'
+        );
+        expect(contents).to.contain(
+          '<output test-ns-prefix="foo-four foo-five foo-six">'
+        );
+        expect(contents).to.contain(
+          '<output test-ns-whitespace="drizzle-seven drizzle-eight drizzle-nine drizzle-ten">'
+        );
+      });
+    });
   });
   describe ('write to page destination', () => {
     var alteredData;


### PR DESCRIPTION
Looking into the feasibility of using PostHTML to automatically prefix classes in HTML with `drizzle-` made me realize a challenge I hadn't considered. 

Because it would need to be done after the Handlebars rendering, there would be no way to differentiate Drizzle UI elements from patterns:

```html
<!-- <drizzle> -->
<div class="u-pad u-cf u-posRelative ">

  <!-- <pattern> -->
  <button class="Button Button--primary">
    Primary Button
  </button>
  <!-- </pattern> -->

</div>
<!-- </drizzle> -->
```

All of the classes (even the pattern ones) would end up with the prefix. The PostHTML [plugin](https://github.com/stevenbenisek/posthtml-prefix-class) provides a way to ignore certain classes, but it doesn't seem applicable because the class naming schemes of both the patterns and the Drizzle UI are typically identical.

So, I thought another solution might be to rely on a Handlebars helper for the prefixing.

It works like this:

```hbs
{{ns "some space-separated words" prefix="ABC-"}}
{{!  ABC-some ABC-space-separated ABC-words  }}
```

```hbs
<div class="{{ns 'u-pad u-cf u-posRelative' prefix='drizzle-'}}"> 
  <button class="Button Button--primary">
    Primary Button
  </button>
</div>

{{!
<div class="drizzle-u-pad drizzle-u-cf drizzle-u-posRelative">
  <button class="Button Button--primary">
    Primary Button
  </button>
</div>
}}
```

The `drizzle-` prefix is set as a default so it isn't needed each time.

/CC @tylersticka @saralohr @nicolemors 