### PR TITLE
Update deep-extend dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1149,9 +1149,9 @@
       }
     },
     "deep-extend": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
-      "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8="
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.5.1.tgz",
+      "integrity": "sha512-N8vBdOa+DF7zkRrDCsaOXoCs/E2fJfx9B9MrKnnSiHNh4ws7eSys6YQE4KvT1cecKmOASYQBhbKjeuDD9lT81w=="
     },
     "deep-is": {
       "version": "0.1.3",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "repository": "cloudfour/drizzle-builder",
   "dependencies": {
     "bluebird": "^3.3.1",
-    "deep-extend": "^0.4.1",
+    "deep-extend": "^0.5.1",
     "front-matter": "^2.0.6",
     "globby": "^4.0.0",
     "handlebars": "^4.0.5",


### PR DESCRIPTION
Updates the `deep-extend` dependency to v0.5.1 to fix a security vulnerability in v0.4.1.